### PR TITLE
Update to simgrid 4.0 and enable autoscaling policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,178 @@
 *.app
 
 build/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,11 @@ include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
 
 MESSAGE("${SimGrid_INCLUDE_DIR}")
 
-
-option(USE_JAEGERTRACING "Use jaeger traces through opentracing" ON)
-configure_file(Elasticity/ElasticConfig.hpp.in ${PROJECT_SOURCE_DIR}/Elasticity/ElasticConfig.hpp)
+if(DEFINED ${USE_JAEGER})
+    option(USE_JAEGERTRACING "Use jaeger traces through opentracing" ON)
+    configure_file(Elasticity/ElasticConfig.hpp.in ${PROJECT_SOURCE_DIR}/Elasticity/ElasticConfig.hpp)
+endif()
+    
 
 add_subdirectory(Elasticity)
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.17)
 
 project(ElasticTask)
 
-set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/")
 
 # Search for SimGrid
@@ -19,6 +20,5 @@ if(DEFINED ${USE_JAEGER})
     configure_file(Elasticity/ElasticConfig.hpp.in ${PROJECT_SOURCE_DIR}/Elasticity/ElasticConfig.hpp)
 endif()
     
-
 add_subdirectory(Elasticity)
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/")
 # Search for SimGrid
 #set(SimGrid_DIR "/home/clem/Code/framagit.org/simgridOfficiel/simgrid/build/" CACHE PATH "Simgrid path")
 
-find_package(SimGrid 3.36 REQUIRED)
+find_package(SimGrid 4 REQUIRED)
 include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
 
 MESSAGE("${SimGrid_INCLUDE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/tools/cmake/")
 # Search for SimGrid
 #set(SimGrid_DIR "/home/clem/Code/framagit.org/simgridOfficiel/simgrid/build/" CACHE PATH "Simgrid path")
 
-find_package(SimGrid REQUIRED)
+find_package(SimGrid 3.36 REQUIRED)
 include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
 
 MESSAGE("${SimGrid_INCLUDE_DIR}")

--- a/Elasticity/CMakeLists.txt
+++ b/Elasticity/CMakeLists.txt
@@ -3,9 +3,12 @@
 # Search for SimGrid
 include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
 
-INCLUDE_DIRECTORIES(SYSTEM /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/include)
-LINK_DIRECTORIES(
-  /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/lib)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# INCLUDE_DIRECTORIES(SYSTEM /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/include)
+# LINK_DIRECTORIES(
+#   /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/lib)
 
 
 if(USE_JAEGERTRACING)

--- a/Elasticity/CMakeLists.txt
+++ b/Elasticity/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-
 # Search for SimGrid
 include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
 
@@ -16,6 +14,6 @@ if(USE_JAEGERTRACING)
 endif()
 
 
-add_library(Elasticity ElasticTask.cpp DataSource.cpp ElasticPolicyCPUThreshold.cpp ElasticPolicyHybrid1.cpp ElasticPolicyReactive1.cpp TaskInstance.cpp)
+add_library(Elasticity ElasticTask.cpp DataSource.cpp ElasticPolicyCPUKubLeast.cpp ElasticPolicyCPUThreshold.cpp ElasticPolicyHybrid1.cpp ElasticPolicyReactive1.cpp TaskInstance.cpp WriteBuffer.cpp)
 target_link_libraries(Elasticity SimGrid::SimGrid)
 TARGET_LINK_LIBRARIES(Elasticity ${EXTRA_LIBS})

--- a/Elasticity/ElasticConfig.hpp
+++ b/Elasticity/ElasticConfig.hpp
@@ -1,7 +1,0 @@
-#define USE_JAEGERTRACING
-
-#ifdef USE_JAEGERTRACING
-#  include <jaegertracing/Tracer.h>
-#  include <yaml-cpp/yaml.h>
-#  include <jaegertracing/Tracer.h>
-#endif

--- a/Elasticity/ElasticPolicy.hpp
+++ b/Elasticity/ElasticPolicy.hpp
@@ -80,6 +80,20 @@ class ElasticPolicyHybrid1: public ElasticPolicy {
     void deploy(int nInst, ElasticTaskManager* etm);
 };
 
+/**
+ * CPU Threshold using Kubernetes Least Allocated strategy (default kubernetes policy)
+ */
+class ElasticPolicyCPUKubLeast: public ElasticPolicy {
+   private:
+      double upperCPUThresh_;
+      double lowCPUThresh_;
+  
+   public:
+      ElasticPolicyCPUKubLeast(double inter, double lowCPUT, double highCPUT);
+      simgrid::s4u::Host* getNextHost(double cores_demanded);
+      virtual void run();
+  };
+
 }  // namespace sg_microserv
 
 #endif  // ELASTICITY_ELASTICPOLICY_HPP_

--- a/Elasticity/ElasticPolicyCPUKubLeast.cpp
+++ b/Elasticity/ElasticPolicyCPUKubLeast.cpp
@@ -39,15 +39,7 @@ void ElasticPolicyCPUKubLeast::run() {
   while (isActive()) {
     // wait until next scaling
     simgrid::s4u::this_actor::sleep_for(getUpdateInterval());
-
-    XBT_INFO("Begin elasticity... VMs available:");
-    auto vms = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 
-    { return (dynamic_cast<simgrid::s4u::VirtualMachine const*>(host)); });
-    for (auto vm : vms)
-    {
-      XBT_INFO("VM: %s state %s", vm->get_cname(), simgrid::s4u::VirtualMachine::to_c_str(dynamic_cast<simgrid::s4u::VirtualMachine const*>(vm)->get_state()));
-    }    
-    
+   
     auto tasks = getTasks();
     for (auto etm : tasks){ 
       std::vector<double> lv = etm->getCPULoads();
@@ -56,8 +48,6 @@ void ElasticPolicyCPUKubLeast::run() {
       for (auto v : lv) s += std::to_string(v)+" " ;
   
       int execInSlot = etm->getCounterExecSlot();
-      XBT_INFO("(before) %s %f %d %ld %ld %d stats", etm->getServiceName().c_str(), avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
-        etm->getAmountOfExecutingRequests(), execInSlot);
   
       etm->resetCounterExecSlot();
   
@@ -65,26 +55,20 @@ void ElasticPolicyCPUKubLeast::run() {
         auto next_host = getNextHost(1);
         if (next_host == nullptr)
         {
-          XBT_INFO("no more hosts to add to service");
+          XBT_INFO("Service %s needs more replicas but there is not host to receive it. Average Load: %f", etm->getServiceName().c_str(), avgLoad);
         }
         else
         {
+          XBT_INFO("Service %s added a new replica in host %s. Average Load: %f", etm->getServiceName().c_str(), next_host->get_cname(), avgLoad);
           etm->addHost(next_host);
         }
       } else if (avgLoad < lowCPUThresh_ && etm->getInstanceAmount() > 1) {
         // if more than one instance, remove one
-        XBT_INFO("remove host");
+        XBT_INFO("Service %s can remove one replica. Average Load: %f", etm->getServiceName().c_str(), avgLoad);
         etm->removeHost(0);
       }
   
       etm->resetCounterExecSlot();
-    }
-    XBT_INFO("Finished elasticity... VMs available:");
-    vms = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 
-    { return (dynamic_cast<simgrid::s4u::VirtualMachine const*>(host)); });
-    for (auto vm : vms)
-    {
-      XBT_INFO("VM: %s state %s", vm->get_cname(), simgrid::s4u::VirtualMachine::to_c_str(dynamic_cast<simgrid::s4u::VirtualMachine const*>(vm)->get_state()));
     }
   }
 }
@@ -100,7 +84,6 @@ simgrid::s4u::Host* ElasticPolicyCPUKubLeast::getNextHost(double cores_demanded)
     while (vms_ptr != vms.end())
     {
       const simgrid::s4u::VirtualMachine *vm = dynamic_cast<simgrid::s4u::VirtualMachine const*>(*vms_ptr);
-      XBT_INFO("VM %s cores %f", vm->get_cname(), vm->get_core_count() * weight_cores);
         if (cores_usage.find(vm->get_pm()->get_name()) == cores_usage.end())
         {
             cores_usage[vm->get_pm()->get_name()] = vm->get_core_count() * weight_cores;
@@ -115,7 +98,6 @@ simgrid::s4u::Host* ElasticPolicyCPUKubLeast::getNextHost(double cores_demanded)
     double load = std::numeric_limits<double>::max();
     for(auto h : hostPool_)
     {
-        XBT_INFO("Host %s available %f", h->get_cname(), (h->get_core_count() - cores_usage[h->get_name()]));
         if (cores_demanded > (h->get_core_count() - cores_usage[h->get_name()]))
             continue;
         // score = (capacity - requested) / capacity

--- a/Elasticity/ElasticPolicyCPUKubLeast.cpp
+++ b/Elasticity/ElasticPolicyCPUKubLeast.cpp
@@ -24,7 +24,7 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(ElasticPolicyCPUKubLeast, "Elastic tasks policy man
     Here, we consider only CPU, but memory can be easily added 
 */
 
-ElasticPolicyCPUKubLeast::ElasticPolicyCPUKubLeast(double interval, double uCPUT, double lCPUT)
+ElasticPolicyCPUKubLeast::ElasticPolicyCPUKubLeast(double interval, double lCPUT, double uCPUT)
   : ElasticPolicy(interval), upperCPUThresh_(uCPUT), lowCPUThresh_(lCPUT)
 {
     hostPool_ = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 

--- a/Elasticity/ElasticPolicyCPUKubLeast.cpp
+++ b/Elasticity/ElasticPolicyCPUKubLeast.cpp
@@ -49,8 +49,6 @@ void ElasticPolicyCPUKubLeast::run() {
   
       int execInSlot = etm->getCounterExecSlot();
   
-      etm->resetCounterExecSlot();
-  
       if (avgLoad > upperCPUThresh_) {
         auto next_host = getNextHost(1);
         if (next_host == nullptr)

--- a/Elasticity/ElasticPolicyCPUKubLeast.cpp
+++ b/Elasticity/ElasticPolicyCPUKubLeast.cpp
@@ -1,0 +1,132 @@
+
+#include <vector>
+#include <iostream>
+#include <numeric>
+#include <simgrid/s4u/Actor.hpp>
+
+#include "ElasticPolicy.hpp"
+#include "ElasticTask.hpp"
+
+#define weight_cores 0.5
+
+// using namespace simgrid;
+// using namespace s4u;
+namespace sg_microserv {
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(ElasticPolicyCPUKubLeast, "Elastic tasks policy manager");
+
+/*  If it is using virtual machines and it does not receive a host:
+    Finds a node using kubernetes LeastAllocated strategy (default) 
+        https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+        https://kubernetes.io/docs/reference/scheduling/config/
+    LeastAllocated: 
+    score = (capacity - requested) / capacity * 10
+    Here, we consider only CPU, but memory can be easily added 
+*/
+
+ElasticPolicyCPUKubLeast::ElasticPolicyCPUKubLeast(double interval, double uCPUT, double lCPUT)
+  : ElasticPolicy(interval), upperCPUThresh_(uCPUT), lowCPUThresh_(lCPUT)
+{
+    hostPool_ = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 
+                                    { return !dynamic_cast<simgrid::s4u::VirtualMachine const*>(host); });
+}
+
+
+void ElasticPolicyCPUKubLeast::run() {
+  int instanceToStartIndex = 0;
+
+  XBT_INFO("ElasticPolicyCPUKubLeast activated");
+  while (isActive()) {
+    // wait until next scaling
+    simgrid::s4u::this_actor::sleep_for(getUpdateInterval());
+
+    XBT_INFO("Begin elasticity... VMs available:");
+    auto vms = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 
+    { return (dynamic_cast<simgrid::s4u::VirtualMachine const*>(host)); });
+    for (auto vm : vms)
+    {
+      XBT_INFO("VM: %s state %s", vm->get_cname(), simgrid::s4u::VirtualMachine::to_c_str(dynamic_cast<simgrid::s4u::VirtualMachine const*>(vm)->get_state()));
+    }    
+    
+    auto tasks = getTasks();
+    for (auto etm : tasks){ 
+      std::vector<double> lv = etm->getCPULoads();
+      double avgLoad = std::accumulate(lv.begin(), lv.end(), 0.0) / lv.size() * 100;
+      std::string s = "";
+      for (auto v : lv) s += std::to_string(v)+" " ;
+  
+      int execInSlot = etm->getCounterExecSlot();
+      XBT_INFO("(before) %s %f %d %ld %ld %d stats", etm->getServiceName().c_str(), avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+        etm->getAmountOfExecutingRequests(), execInSlot);
+  
+      etm->resetCounterExecSlot();
+  
+      if (avgLoad > upperCPUThresh_) {
+        auto next_host = getNextHost(1);
+        if (next_host == nullptr)
+        {
+          XBT_INFO("no more hosts to add to service");
+        }
+        else
+        {
+          etm->addHost(next_host);
+        }
+      } else if (avgLoad < lowCPUThresh_ && etm->getInstanceAmount() > 1) {
+        // if more than one instance, remove one
+        XBT_INFO("remove host");
+        etm->removeHost(0);
+      }
+  
+      etm->resetCounterExecSlot();
+    }
+    XBT_INFO("Finished elasticity... VMs available:");
+    vms = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 
+    { return (dynamic_cast<simgrid::s4u::VirtualMachine const*>(host)); });
+    for (auto vm : vms)
+    {
+      XBT_INFO("VM: %s state %s", vm->get_cname(), simgrid::s4u::VirtualMachine::to_c_str(dynamic_cast<simgrid::s4u::VirtualMachine const*>(vm)->get_state()));
+    }
+  }
+}
+
+simgrid::s4u::Host* ElasticPolicyCPUKubLeast::getNextHost(double cores_demanded)
+{
+    auto vms = simgrid::s4u::Engine::get_instance()->get_filtered_hosts([](const simgrid::s4u::Host* host) 
+    { return (dynamic_cast<simgrid::s4u::VirtualMachine const*>(host) && dynamic_cast<simgrid::s4u::VirtualMachine const*>(host)->get_state() == simgrid::s4u::VirtualMachine::State::CREATED); });
+    std::map<std::string, double> cores_usage;
+    auto vms_ptr = vms.begin();
+    // Adapt the number of cores, because they share the core
+    cores_demanded *= weight_cores;
+    while (vms_ptr != vms.end())
+    {
+      const simgrid::s4u::VirtualMachine *vm = dynamic_cast<simgrid::s4u::VirtualMachine const*>(*vms_ptr);
+      XBT_INFO("VM %s cores %f", vm->get_cname(), vm->get_core_count() * weight_cores);
+        if (cores_usage.find(vm->get_pm()->get_name()) == cores_usage.end())
+        {
+            cores_usage[vm->get_pm()->get_name()] = vm->get_core_count() * weight_cores;
+        }
+        else
+        {
+            cores_usage[vm->get_pm()->get_name()] += vm->get_core_count() * weight_cores;
+        }
+        vms_ptr++;
+    }
+    simgrid::s4u::Host* host = nullptr;
+    double load = std::numeric_limits<double>::max();
+    for(auto h : hostPool_)
+    {
+        XBT_INFO("Host %s available %f", h->get_cname(), (h->get_core_count() - cores_usage[h->get_name()]));
+        if (cores_demanded > (h->get_core_count() - cores_usage[h->get_name()]))
+            continue;
+        // score = (capacity - requested) / capacity
+        double load_host = ((h->get_core_count() - cores_usage[h->get_name()]) / h->get_core_count());
+        if (load > load_host)
+        {
+            load = load_host;
+            host = h;
+        }
+    }
+    return host;
+}
+
+}  // namespace sg_microserv

--- a/Elasticity/ElasticPolicyCPUThreshold.cpp
+++ b/Elasticity/ElasticPolicyCPUThreshold.cpp
@@ -37,7 +37,7 @@ void ElasticPolicyCPUThreshold::run() {
     for (auto v : lv) s += std::to_string(v)+" " ;
 
     int execInSlot = etm->getCounterExecSlot();
-    XBT_INFO("%f %d %d %d %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+    XBT_INFO("%f %d %ld %ld %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
       etm->getAmountOfExecutingRequests(), execInSlot, etm->reqPerSec()*getUpdateInterval());
 
     etm->resetCounterExecSlot();
@@ -61,7 +61,7 @@ void ElasticPolicyCPUThreshold::run() {
         hostPool_.push_back(h);
     }
 
-    XBT_INFO("%f %d %d %d %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+    XBT_INFO("%f %d %ld %ld %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
       etm->getAmountOfExecutingRequests(), execInSlot, etm->reqPerSec()*getUpdateInterval());
     etm->resetCounterExecSlot();
 

--- a/Elasticity/ElasticPolicyHybrid1.cpp
+++ b/Elasticity/ElasticPolicyHybrid1.cpp
@@ -96,7 +96,7 @@ void ElasticPolicyHybrid1::run() {
     std::vector<double> lv = etm->getCPULoads();
     double avgLoad = std::accumulate(lv.begin(), lv.end(), 0.0) / lv.size();
     std::string s = "";
-    XBT_INFO("%f %d %d %d %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+    XBT_INFO("%f %d %ld %ld %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
       etm->getAmountOfExecutingRequests(), execInSlot, etm->reqPerSec()*getUpdateInterval());
 
     etm->resetCounterExecSlot();
@@ -114,7 +114,7 @@ void ElasticPolicyHybrid1::run() {
       deploy(static_cast<int>(nProactive), etm);
     }
 
-    XBT_INFO("%f %d %d %d %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+    XBT_INFO("%f %d %ld %ld %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
       etm->getAmountOfExecutingRequests(), execInSlot, etm->reqPerSec()*getUpdateInterval());
   }
 }

--- a/Elasticity/ElasticPolicyReactive1.cpp
+++ b/Elasticity/ElasticPolicyReactive1.cpp
@@ -51,7 +51,7 @@ void ElasticPolicyReactive1::run() {
     int execInSlot = etm->getCounterExecSlot();
     std::vector<double> lv = etm->getCPULoads();
     double avgLoad = std::accumulate(lv.begin(), lv.end(), 0.0) / lv.size();
-    XBT_INFO("%f %d %d %d %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+    XBT_INFO("%f %d %ld %ld %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
       etm->getAmountOfExecutingRequests(), execInSlot, etm->reqPerSec()*getUpdateInterval());
     etm->resetCounterExecSlot();
 
@@ -66,7 +66,7 @@ void ElasticPolicyReactive1::run() {
         etm->removeHost(0);
       }
     }
-    XBT_INFO("%f %d %d %d %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
+    XBT_INFO("%f %d %ld %ld %d %f stats", avgLoad, etm->getInstanceAmount(), etm->getAmountOfWaitingRequests(),
       etm->getAmountOfExecutingRequests(), execInSlot, etm->reqPerSec()*getUpdateInterval());
     etm->resetCounterExecSlot();
 

--- a/Elasticity/ElasticTask.cpp
+++ b/Elasticity/ElasticTask.cpp
@@ -5,342 +5,414 @@
 #include <sstream>
 #include <utility>
 #include <iostream>
-#include "simgrid/s4u.hpp"
-#include "simgrid/kernel/future.hpp"
 #include "simgrid/plugins/load.h"
 #include <simgrid/Exception.hpp>
 
 #include "ElasticTask.hpp"
 
-// using namespace simgrid;
-// using namespace s4u;
-namespace sg_microserv {
+namespace sg_microserv
+{
 
-XBT_LOG_NEW_DEFAULT_CATEGORY(elastic, "elastic tasks");
+  XBT_LOG_NEW_DEFAULT_CATEGORY(elastic, "elastic tasks");
 
 #ifdef USE_JAEGERTRACING
 
-std::shared_ptr<opentracing::v3::Tracer> setUpTracer(const char* configFilePath, std::string name) {
-  XBT_INFO("set up jaeger tracer for %s", name.c_str());
+  std::shared_ptr<opentracing::v3::Tracer> setUpTracer(const char *configFilePath, std::string name)
+  {
+    XBT_INFO("set up jaeger tracer for %s", name.c_str());
     auto configYAML = YAML::LoadFile(configFilePath);
     auto config = jaegertracing::Config::parse(configYAML);
     auto tracer = jaegertracing::Tracer::make(
         name, config, jaegertracing::logging::consoleLogger());
     return tracer;
-}
+  }
 #endif
 
-ElasticTaskManager::ElasticTaskManager(std::string name,
-  std::vector<std::string> incMailboxes, std::string jaegConfigFile)
-  : serviceName_(name), incMailboxes_(incMailboxes), nextHost_(0),
-    keepGoing(true), defCPUCost_(1e7), waitingReqAmount_(0),
-    bootDuration_(0), executingReqAmount_(0), counterExecSlot_(0),
-    parallelTasksPerInst_(100), defCPURatio_(1) {
-  XBT_DEBUG("Creating TaskManager %s", serviceName_.c_str());
-  sg_host_load_plugin_init();
-  sleep_sem = simgrid::s4u::Semaphore::create(0);
-  modif_sem_ = simgrid::s4u::Semaphore::create(1);
+  ElasticTaskManager::ElasticTaskManager(std::string name,
+                                         std::vector<std::string> incMailboxes, std::string jaegConfigFile)
+      : serviceName_(name), incMailboxes_(incMailboxes), nextHost_(0),
+        keepGoing(true), defCPUCost_(1e7), waitingReqAmount_(0),
+        bootDuration_(0), executingReqAmount_(0), counterExecSlot_(0),
+        parallelTasksPerInst_(100), defCPURatio_(1)
+  {
+    XBT_DEBUG("Creating TaskManager %s", serviceName_.c_str());
+    sg_host_load_plugin_init();
+    sleep_sem = Semaphore::create(0);
+    modif_sem_ = Semaphore::create(1);
 
 #ifdef USE_JAEGERTRACING
-  tracer_ = setUpTracer(jaegConfigFile.c_str(), serviceName_.c_str());
+    tracer_ = setUpTracer(jaegConfigFile.c_str(), serviceName_.c_str());
 #endif
-}
-ElasticTaskManager::ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes)
-  : ElasticTaskManager(name, incMailboxes, "config.yml")
-{}
-
-ElasticTaskManager::ElasticTaskManager(std::string name)
-  : ElasticTaskManager(name, std::vector<std::string>(1, name), "config.yml")
-{}
-
-void ElasticTaskManager::setExecAmount(int64_t pr) {
-  xbt_assert(pr >= 0, "Cannot have a negative processRatio. you asked for: %d", pr);
-  XBT_DEBUG("changed default process cost per request: %d -> %d", defCPUCost_, pr);
-  defCPUCost_ = pr;
-}
-
-void ElasticTaskManager::setExecRatio(double cost) {
-  xbt_assert(cost >= 0, "Cannot have a negative amount of IO, you asked for: %lf", cost);
-  XBT_DEBUG("changed default I/O cost per request: %lf -> %lf", defCPURatio_, cost);
-  defCPURatio_ = cost;
-}
-
-void ElasticTaskManager::setParallelTasksPerInst(int s) {
-  xbt_assert(s > 0, "Instances cannot execute a negative amount of tasks in parallel");
-  XBT_DEBUG("new max amount of parallel tasks per instance: %d -> %d", parallelTasksPerInst_, s);
-  parallelTasksPerInst_ = s;
-}
-
-void ElasticTaskManager::setExecAmountFunc(std::function<double(TaskDescription*)> costReqType) {
-  XBT_DEBUG("Set a new process cost function.");
-  fCPUCost = costReqType;
-}
-
-void ElasticTaskManager::setExecRatioFunction(std::function<double(TaskDescription*)> costIOType) {
-  XBT_DEBUG("Set a new IO cost function.");
-  fCPURatio_ = costIOType;
-}
-
-
-void ElasticTaskManager::addHost(simgrid::s4u::Host *host) {
-  availableHostsList_.push_back(host);
-  TaskInstance* ti = new TaskInstance(this, serviceName_+"_data", outputFunction, parallelTasksPerInst_);
-  tiList.push_back(ti);
-
-  XBT_DEBUG("Created a new service instance on host %s. Total # instances is now %d",
-     host->get_cname(), availableHostsList_.size());
-  simgrid::s4u::Actor::create("TI"+boost::uuids::to_string(boost::uuids::random_generator()()), host, [&]{ti->run();});
-}
-
-
-void ElasticTaskManager::setBootDuration(double bd) {
-  xbt_assert(bd >= 0, "Boot time has to be non negative, you asked for %lf", bd);
-  bootDuration_ = bd;
-}
-
-void ElasticTaskManager::trigger(TaskDescription* td) {
-  xbt_assert(td != nullptr, "Triggered a nullptr, problem");
-  // when we trigger an event, it means it reached the service correctly, thus we made a hop
-  td->nbHops++;
-  td->date = simgrid::s4u::Engine::get_instance()->get_clock();
-  nextEvtQueue.push(td);
-  // one more pending request
-  modifWaitingReqAmount(1);
-  sleep_sem->release();
-}
-
-simgrid::s4u::Host* ElasticTaskManager::removeHost(int i) {
-  xbt_assert(availableHostsList_.size() > 1,
-    "You asked for removing the last instance of the service. Cannot have 0 instances.");
-  simgrid::s4u::Host* h;
-  if (i < availableHostsList_.size()) {
-    h =  availableHostsList_.at(i);
-    availableHostsList_.erase(availableHostsList_.begin()+i);
-    TaskInstance* ti = tiList.at(i);
-    ti->kill();
-    delete ti;
-    tiList.erase(tiList.begin()+i);
-  } else {
-    XBT_INFO("Cannot remove element at position %d, overflow", i);
   }
-  return h;
-}
-
-unsigned int ElasticTaskManager::getInstanceAmount() {
-  return availableHostsList_.size();
-}
-std::vector<double> ElasticTaskManager::getCPULoads() {
-  std::vector<double> v;
-  for (int i=0; i < availableHostsList_.size() ; i++) {
-    v.push_back(sg_host_get_avg_load(availableHostsList_.at(i)));
-    sg_host_load_reset(availableHostsList_.at(i));
+  ElasticTaskManager::ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes)
+      : ElasticTaskManager(name, incMailboxes, "config.yml")
+  {
   }
-  return v;
-}
 
-void ElasticTaskManager::modifExecutingReqAmount(int n) {
-  modif_sem_->acquire();
-  executingReqAmount_+=n;
-  xbt_assert(executingReqAmount_ >= 0,
-    "cannot have less than 0 executing requests");
-  modif_sem_->release();
-}
+  ElasticTaskManager::ElasticTaskManager(std::string name)
+      : ElasticTaskManager(name, std::vector<std::string>(1, name), "config.yml")
+  {
+  }
 
-void ElasticTaskManager::modifWaitingReqAmount(int n) {
-  modif_sem_->acquire();
-  waitingReqAmount_+=n;
-  xbt_assert(waitingReqAmount_ >= 0, "cannot have less than 0 waiting requests");
-  modif_sem_->release();
-}
+  void ElasticTaskManager::setExecAmount(int64_t pr)
+  {
+    xbt_assert(pr >= 0, "Cannot have a negative processRatio. you asked for: %ld", pr);
+    XBT_DEBUG("changed default process cost per request: %ld -> %ld", defCPUCost_, pr);
+    defCPUCost_ = pr;
+  }
 
-int64_t ElasticTaskManager::getAmountOfWaitingRequests() {
-  return waitingReqAmount_;
-}
+  void ElasticTaskManager::setExecRatio(double cost)
+  {
+    xbt_assert(cost >= 0, "Cannot have a negative amount of IO, you asked for: %lf", cost);
+    XBT_DEBUG("changed default I/O cost per request: %lf -> %lf", defCPURatio_, cost);
+    defCPURatio_ = cost;
+  }
 
-int64_t ElasticTaskManager::getAmountOfExecutingRequests() {
-  return executingReqAmount_;
-}
+  void ElasticTaskManager::setParallelTasksPerInst(int s)
+  {
+    xbt_assert(s > 0, "Instances cannot execute a negative amount of tasks in parallel");
+    XBT_DEBUG("new max amount of parallel tasks per instance: %d -> %d", parallelTasksPerInst_, s);
+    parallelTasksPerInst_ = s;
+  }
 
-void ElasticTaskManager::setOutputFunction(std::function<void(TaskDescription*)> f) {
-  outputFunction = f;
-}
+  void ElasticTaskManager::setExecAmountFunc(std::function<double(TaskDescription *)> costReqType)
+  {
+    XBT_DEBUG("Set a new process cost function.");
+    fCPUCost = costReqType;
+  }
+
+  void ElasticTaskManager::setExecRatioFunction(std::function<double(TaskDescription *)> costIOType)
+  {
+    XBT_DEBUG("Set a new IO cost function.");
+    fCPURatio_ = costIOType;
+  }
+
+  void ElasticTaskManager::addHost(Host *host)
+  {
+    availableHostsList_.push_back(host);
+    TaskInstance *ti = new TaskInstance(this, serviceName_ + "_data", outputFunction, parallelTasksPerInst_);
+    tiList.push_back(ti);
+
+    XBT_DEBUG("Created a new service instance on host %s. Total # instances is now %ld",
+              host->get_cname(), availableHostsList_.size());
+    Actor::create("TI" + boost::uuids::to_string(boost::uuids::random_generator()()), host, [&]
+                  { ti->run(); });
+  }
+
+  void ElasticTaskManager::setBootDuration(double bd)
+  {
+    xbt_assert(bd >= 0, "Boot time has to be non negative, you asked for %lf", bd);
+    bootDuration_ = bd;
+  }
+
+  void ElasticTaskManager::trigger(TaskDescription *td)
+  {
+    xbt_assert(td != nullptr, "Triggered a nullptr, problem");
+    // when we trigger an event, it means it reached the service correctly, thus we made a hop
+    td->nbHops++;
+    td->date = Engine::get_instance()->get_clock();
+    nextEvtQueue.push(td);
+    // one more pending request
+    modifWaitingReqAmount(1);
+    sleep_sem->release();
+  }
+
+  Host *ElasticTaskManager::removeHost(int i)
+  {
+    xbt_assert(availableHostsList_.size() > 1,
+               "You asked for removing the last instance of the service. Cannot have 0 instances.");
+    Host *h;
+    if (i < availableHostsList_.size())
+    {
+      h = availableHostsList_.at(i);
+      availableHostsList_.erase(availableHostsList_.begin() + i);
+      TaskInstance *ti = tiList.at(i);
+      ti->kill();
+      delete ti;
+      tiList.erase(tiList.begin() + i);
+    }
+    else
+    {
+      XBT_INFO("Cannot remove element at position %d, overflow", i);
+    }
+    return h;
+  }
+
+  unsigned int ElasticTaskManager::getInstanceAmount()
+  {
+    return availableHostsList_.size();
+  }
+  std::vector<double> ElasticTaskManager::getCPULoads()
+  {
+    std::vector<double> v;
+    for (int i = 0; i < availableHostsList_.size(); i++)
+    {
+      v.push_back(sg_host_get_avg_load(availableHostsList_.at(i)));
+      sg_host_load_reset(availableHostsList_.at(i));
+    }
+    return v;
+  }
+
+  void ElasticTaskManager::modifExecutingReqAmount(int n)
+  {
+    modif_sem_->acquire();
+    executingReqAmount_ += n;
+    xbt_assert(executingReqAmount_ >= 0,
+               "cannot have less than 0 executing requests");
+    modif_sem_->release();
+  }
+
+  void ElasticTaskManager::modifWaitingReqAmount(int n)
+  {
+    modif_sem_->acquire();
+    waitingReqAmount_ += n;
+    xbt_assert(waitingReqAmount_ >= 0, "cannot have less than 0 waiting requests");
+    modif_sem_->release();
+  }
+
+  int64_t ElasticTaskManager::getAmountOfWaitingRequests()
+  {
+    return waitingReqAmount_;
+  }
+
+  int64_t ElasticTaskManager::getAmountOfExecutingRequests()
+  {
+    return executingReqAmount_;
+  }
+
+  void ElasticTaskManager::setOutputFunction(std::function<void(TaskDescription *)> f)
+  {
+    outputFunction = f;
+  }
 
 #ifdef USE_JAEGERTRACING
-std::shared_ptr<opentracing::v3::Tracer> ElasticTaskManager::getTracer() {
-  return tracer_;
-}
+  std::shared_ptr<opentracing::v3::Tracer> ElasticTaskManager::getTracer()
+  {
+    return tracer_;
+  }
 #endif
 
-double ElasticTaskManager::reqPerSec() {
-  xbt_assert(!fCPUCost, "TODO: cannot compute the reqpersec value with this function if cost function is set");
-  double tot = 0;
-  for (auto i : tiList) {
-    simgrid::s4u::Host* a = i->getRunningHost();
-    if (a)
-      tot+=(a->get_pstate_speed(a->get_pstate())*a->get_core_count())/defCPUCost_;
-  }
-  return tot;
-}
-
-void ElasticTaskManager::setReqNames(std::function<std::string(RequestType)> rnToStr) {
-  reqTypeToStr_ = rnToStr;
-}
-
-double ElasticTaskManager::getCPUExecAmount(TaskDescription* e) {
-  // if the function is defined, use it, otherwise use the single value
-  if (fCPUCost) {
-    return fCPUCost(e);
-  } else {
-    return defCPUCost_;
-  }
-}
-
-double ElasticTaskManager::getExecRatio(TaskDescription* e) {
-  double ratio = -1;
-  if (fCPURatio_) {
-    ratio = fCPURatio_(e);
-  } else {
-    ratio = defCPURatio_;
-  }
-  xbt_assert(ratio >= 0, "Cannot use an execution ratio below 0, you provided %lf", ratio);
-  XBT_DEBUG("Execution ratio for request %p = %lf", e, ratio);
-  return ratio;
-}
-
-std::string ElasticTaskManager::getStrFromReqType(RequestType r) {
-  if (reqTypeToStr_) {
-    return reqTypeToStr_(r);
-  } else {
-    XBT_DEBUG("No reqTypeToStr_ provided, return service name");
-    return serviceName_;
-  }
-}
-
-/**
- * Will stop run()'s infinite loop
- */
-void ElasticTaskManager::kill() {
-  XBT_INFO("KILL ETM");
-  keepGoing = false;
-  for (int i=0 ; i < tiList.size() ; i++) {
-    tiList.at(i)->kill();
+  double ElasticTaskManager::reqPerSec()
+  {
+    xbt_assert(!fCPUCost, "TODO: cannot compute the reqpersec value with this function if cost function is set");
+    double tot = 0;
+    for (auto i : tiList)
+    {
+      Host *a = i->getRunningHost();
+      if (a)
+        tot += (a->get_pstate_speed(a->get_pstate()) * a->get_core_count()) / defCPUCost_;
+    }
+    return tot;
   }
 
-  for (auto a : pollers_) {
-    a->kill();
-  }
-}
-
-void ElasticTaskManager::pollnet(std::string mboxName) {
-  simgrid::s4u::Mailbox* recvMB = simgrid::s4u::Mailbox::by_name(mboxName.c_str());
-
-  int parComSize = parallelTasksPerInst_;
-  XBT_DEBUG("start poll with %d parallel get_async", parallelTasksPerInst_);
-  TaskDescription* tasksV[parComSize];
-  std::vector<simgrid::s4u::CommPtr> commV;
-  for (int i=0 ; i < parComSize ; i++) {
-    commV.push_back(recvMB->get_async<TaskDescription>(&(tasksV[i])));
+  void ElasticTaskManager::setReqNames(std::function<std::string(RequestType)> rnToStr)
+  {
+    reqTypeToStr_ = rnToStr;
   }
 
-  while (keepGoing) {
-    int newMsgPos = simgrid::s4u::Comm::wait_any(&commV);
-    TaskDescription* taskRequest = tasksV[newMsgPos];
+  double ElasticTaskManager::getCPUExecAmount(TaskDescription *e)
+  {
+    // if the function is defined, use it, otherwise use the single value
+    if (fCPUCost)
+    {
+      return fCPUCost(e);
+    }
+    else
+    {
+      return defCPUCost_;
+    }
+  }
 
-    // set amount of computation for the instance
-    taskRequest->queueArrival = simgrid::s4u::Engine::get_clock();
+  double ElasticTaskManager::getExecRatio(TaskDescription *e)
+  {
+    double ratio = -1;
+    if (fCPURatio_)
+    {
+      ratio = fCPURatio_(e);
+    }
+    else
+    {
+      ratio = defCPURatio_;
+    }
+    xbt_assert(ratio >= 0, "Cannot use an execution ratio below 0, you provided %lf", ratio);
+    XBT_DEBUG("Execution ratio for request %p = %lf", e, ratio);
+    return ratio;
+  }
 
-    commV.erase(commV.begin() + newMsgPos);
-    commV.insert(commV.begin() + newMsgPos, recvMB->get_async<TaskDescription>(&(tasksV[newMsgPos])));
+  std::string ElasticTaskManager::getStrFromReqType(RequestType r)
+  {
+    if (reqTypeToStr_)
+    {
+      return reqTypeToStr_(r);
+    }
+    else
+    {
+      XBT_DEBUG("No reqTypeToStr_ provided, return service name");
+      return serviceName_;
+    }
+  }
 
-    XBT_DEBUG("Received %p index: %d", taskRequest, newMsgPos);
+  /**
+   * Will stop run()'s infinite loop
+   */
+  void ElasticTaskManager::kill()
+  {
+    XBT_INFO("KILL ETM");
+    keepGoing = false;
+    for (int i = 0; i < tiList.size(); i++)
+    {
+      tiList.at(i)->kill();
+    }
 
-    if (incMailboxes_.size() == 1) {
-      trigger(taskRequest);
-      sleep_sem->release();
-    } else {
-      std::vector<TaskDescription*> v =
-        (tempData.find(taskRequest->id_) != tempData.end()) ?
-          tempData.find(taskRequest->id_)->second : std::vector<TaskDescription*>();
+    for (auto a : pollers_)
+    {
+      a->kill();
+    }
+  }
 
-      v.push_back(taskRequest);
-      tempData.insert(std::pair<boost::uuids::uuid, std::vector<TaskDescription*>>(taskRequest->id_, v));
+  void ElasticTaskManager::pollnet(std::string mboxName)
+  {
+    Mailbox *recvMB = Mailbox::by_name(mboxName.c_str());
 
-      if (v.size() == incMailboxes_.size()) {
-        XBT_DEBUG("Received %d for %p, trigger now", v.size(), taskRequest);
+    int parComSize = parallelTasksPerInst_;
+    XBT_DEBUG("start poll with %d parallel get_async", parallelTasksPerInst_);
+    std::unordered_map<CommPtr, std::shared_ptr<TaskDescription *>> pending_msgs;
+    ActivitySet commV;
+    for (int i = 0; i < parComSize; i++)
+    {
+      auto msg = std::make_shared<TaskDescription *>();
+      auto comm = recvMB->get_async<TaskDescription>(msg.get());
+      commV.push(comm);
+      pending_msgs.insert({comm, msg});
+    }
+
+    while (keepGoing)
+    {
+      auto newMsgPos = commV.wait_any();
+      if (newMsgPos == nullptr)
+      {
+        continue;
+      }
+      auto comm = boost::dynamic_pointer_cast<Comm>(newMsgPos);
+      TaskDescription *taskRequest = *pending_msgs[comm];
+      pending_msgs.erase(comm);
+
+      // set amount of computation for the instance
+      taskRequest->queueArrival = Engine::get_clock();
+
+      auto msg = std::make_shared<TaskDescription *>();
+      auto newcomm = recvMB->get_async<TaskDescription>(msg.get());
+      commV.push(newcomm);
+      pending_msgs.insert({newcomm, msg});
+
+      XBT_DEBUG("Received %p", taskRequest);
+
+      if (incMailboxes_.size() == 1)
+      {
         trigger(taskRequest);
-        // remove data
-        tempData.erase(taskRequest->id_);
         sleep_sem->release();
       }
-    }
-  }
-}
-
-/**
- * Supervisor of the elastictasks
- * Fetches events at their execution time and creates a new microtask
- * on one of the provided hosts
- */
-void ElasticTaskManager::run() {
-  int64_t task_count = 0;
-
-  for (auto s : incMailboxes_) {
-    simgrid::s4u::Mailbox* rec = simgrid::s4u::Mailbox::by_name(s.c_str());
-    pollers_.push_back(simgrid::s4u::Actor::create(
-      serviceName_+"_"+s+"polling", simgrid::s4u::Host::current(), [&]{pollnet(s);}));
-    XBT_INFO("polling on mailbox %s", s.c_str());
-  }
-
-  while (1) {
-    for (std::vector<simgrid::s4u::CommPtr>::iterator it = pending_comms.begin(); it != pending_comms.end();) {
-      if ((*it)->test())
-        it = pending_comms.erase(it);
       else
-        it++;
-    }
-    // execute events that need be executed now
-    while (!nextEvtQueue.empty() && nextEvtQueue.top()->date <= simgrid::s4u::Engine::get_instance()->get_clock()) {
-      EvntQ *currentEvent = nextEvtQueue.top();
-      nextEvtQueue.pop();
-      XBT_DEBUG("add: %p", currentEvent);
-      TaskDescription* t = dynamic_cast<TaskDescription*>(currentEvent);
-      if (availableHostsList_.size() <= nextHost_)
-        nextHost_ = 0;
-      simgrid::s4u::Mailbox* mbp = simgrid::s4u::Mailbox::by_name(serviceName_+"_data");
+      {
+        std::vector<TaskDescription *> v =
+            (tempData.find(taskRequest->id_) != tempData.end()) ? tempData.find(taskRequest->id_)->second : std::vector<TaskDescription *>();
 
-      /* Async version TODO: clean pending vector */
-      XBT_DEBUG("Send %p to task", t);
-      t->flopsPerServ.push_back(getCPUExecAmount(t));
-      if (!t->dSize || t->dSize == -1) {t->dSize = 1; XBT_DEBUG("NO SIZE SET, PUT TO 1");}
-      simgrid::s4u::CommPtr comm = mbp->put_async(t, (t->dSize == -1) ? 1 : t->dSize);
-      pending_comms.push_back(comm);
+        v.push_back(taskRequest);
+        tempData.insert(std::pair<boost::uuids::uuid, std::vector<TaskDescription *>>(taskRequest->id_, v));
 
-      ++task_count;
-
-      nextHost_++;
-      nextHost_ = nextHost_ % availableHostsList_.size();
+        if (v.size() == incMailboxes_.size())
+        {
+          XBT_DEBUG("Received %ld for %p, trigger now", v.size(), taskRequest);
+          trigger(taskRequest);
+          // remove data
+          tempData.erase(taskRequest->id_);
+          sleep_sem->release();
+        }
       }
-    if (!keepGoing) {
-      break;
-    }
-
-    XBT_DEBUG("RUN: going to sleep on semaphore");
-    if (!nextEvtQueue.empty()) {
-      sleep_sem->acquire_timeout(nextEvtQueue.top()->date - simgrid::s4u::Engine::get_instance()->get_clock());
-    } else {
-      sleep_sem->acquire_timeout(999.0);
     }
   }
-}
 
-ElasticTaskManager::~ElasticTaskManager() {
-  // cancel active communications
-  for (auto c : pending_comms) {
-    c->cancel();
+  /**
+   * Supervisor of the elastictasks
+   * Fetches events at their execution time and creates a new microtask
+   * on one of the provided hosts
+   */
+  void ElasticTaskManager::run()
+  {
+    int64_t task_count = 0;
+
+    for (auto s : incMailboxes_)
+    {
+      Mailbox *rec = Mailbox::by_name(s.c_str());
+      pollers_.push_back(Actor::create(
+          serviceName_ + "_" + s + "polling", Host::current(), [&]
+          { pollnet(s); }));
+      XBT_INFO("polling on mailbox %s", s.c_str());
+    }
+
+    while (1)
+    {
+      for (std::vector<CommPtr>::iterator it = pending_comms.begin(); it != pending_comms.end();)
+      {
+        if ((*it)->test())
+          it = pending_comms.erase(it);
+        else
+          it++;
+      }
+      // execute events that need be executed now
+      while (!nextEvtQueue.empty() && nextEvtQueue.top()->date <= Engine::get_instance()->get_clock())
+      {
+        EvntQ *currentEvent = nextEvtQueue.top();
+        nextEvtQueue.pop();
+        XBT_DEBUG("add: %p", currentEvent);
+        TaskDescription *t = dynamic_cast<TaskDescription *>(currentEvent);
+        if (availableHostsList_.size() <= nextHost_)
+          nextHost_ = 0;
+        Mailbox *mbp = Mailbox::by_name(serviceName_ + "_data");
+
+        /* Async version TODO: clean pending vector */
+        XBT_DEBUG("Send %p to task", t);
+        t->flopsPerServ.push_back(getCPUExecAmount(t));
+        if (!t->dSize || t->dSize == -1)
+        {
+          t->dSize = 1;
+          XBT_DEBUG("NO SIZE SET, PUT TO 1");
+        }
+        CommPtr comm = mbp->put_async(t, (t->dSize == -1) ? 1 : t->dSize);
+        pending_comms.push_back(comm);
+
+        ++task_count;
+
+        nextHost_++;
+        nextHost_ = nextHost_ % availableHostsList_.size();
+      }
+      if (!keepGoing)
+      {
+        break;
+      }
+
+      XBT_DEBUG("RUN: going to sleep on semaphore");
+      if (!nextEvtQueue.empty())
+      {
+        sleep_sem->acquire_timeout(nextEvtQueue.top()->date - Engine::get_instance()->get_clock());
+      }
+      else
+      {
+        sleep_sem->acquire_timeout(999.0);
+      }
+    }
   }
 
-  // delete instances
-  tiList.clear();
-}
+  ElasticTaskManager::~ElasticTaskManager()
+  {
+    // cancel active communications
+    for (auto c : pending_comms)
+    {
+      c->cancel();
+    }
 
-}  // namespace sg_microserv
+    // delete instances
+    tiList.clear();
+  }
+
+} // namespace sg_microserv

--- a/Elasticity/ElasticTask.cpp
+++ b/Elasticity/ElasticTask.cpp
@@ -139,10 +139,8 @@ namespace sg_microserv
       tiList.erase(tiList.begin() + i);
       if (use_virtual_machines_)
       {
-        XBT_INFO("Turn off virtual machine %s", h->get_cname());
         dynamic_cast<VirtualMachine*>(h)->shutdown();
         h = nullptr;
-        XBT_INFO("Done");
       }
     }
     else

--- a/Elasticity/ElasticTask.cpp
+++ b/Elasticity/ElasticTask.cpp
@@ -29,14 +29,19 @@ namespace sg_microserv
 #endif
 
   ElasticTaskManager::ElasticTaskManager(std::string name,
-                                         std::vector<std::string> incMailboxes, std::string jaegConfigFile)
-      : serviceName_(name), incMailboxes_(incMailboxes), nextHost_(0),
+                                         std::vector<std::string> incMailboxes, 
+                                         std::string jaegConfigFile,
+                                         bool use_virtual_machines)
+      : serviceName_(name), incMailboxes_(incMailboxes),
         keepGoing(true), defCPUCost_(1e7), waitingReqAmount_(0),
         bootDuration_(0), executingReqAmount_(0), counterExecSlot_(0),
-        parallelTasksPerInst_(100), defCPURatio_(1)
+        parallelTasksPerInst_(100), defCPURatio_(1), use_virtual_machines_(use_virtual_machines)
   {
     XBT_DEBUG("Creating TaskManager %s", serviceName_.c_str());
-    sg_host_load_plugin_init();
+    if (use_virtual_machines_)
+      sg_vm_load_plugin_init();
+    else
+      sg_host_load_plugin_init();
     sleep_sem = Semaphore::create(0);
     modif_sem_ = Semaphore::create(1);
 
@@ -44,13 +49,13 @@ namespace sg_microserv
     tracer_ = setUpTracer(jaegConfigFile.c_str(), serviceName_.c_str());
 #endif
   }
-  ElasticTaskManager::ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes)
-      : ElasticTaskManager(name, incMailboxes, "config.yml")
+  ElasticTaskManager::ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes, bool use_virtual_machines)
+      : ElasticTaskManager(name, incMailboxes, "config.yml", use_virtual_machines)
   {
   }
 
-  ElasticTaskManager::ElasticTaskManager(std::string name)
-      : ElasticTaskManager(name, std::vector<std::string>(1, name), "config.yml")
+  ElasticTaskManager::ElasticTaskManager(std::string name, bool use_virtual_machines)
+      : ElasticTaskManager(name, std::vector<std::string>(1, name), "config.yml", use_virtual_machines)
   {
   }
 
@@ -89,14 +94,16 @@ namespace sg_microserv
 
   void ElasticTaskManager::addHost(Host *host)
   {
+    if (use_virtual_machines_)
+    {
+      host = host->create_vm("VM_" + serviceName_ + "_" +boost::uuids::to_string(boost::uuids::random_generator()()), 1);
+    }
     availableHostsList_.push_back(host);
     TaskInstance *ti = new TaskInstance(this, serviceName_ + "_data", outputFunction, parallelTasksPerInst_);
     tiList.push_back(ti);
 
-    XBT_DEBUG("Created a new service instance on host %s. Total # instances is now %ld",
-              host->get_cname(), availableHostsList_.size());
-    Actor::create("TI" + boost::uuids::to_string(boost::uuids::random_generator()()), host, [&]
-                  { ti->run(); });
+    XBT_DEBUG("Created a new service instance on host %s. Total # instances is now %ld", host->get_cname(), availableHostsList_.size());
+    Engine::get_instance()->add_actor("TI" + boost::uuids::to_string(boost::uuids::random_generator()()), host, [&] { ti->run(); });
   }
 
   void ElasticTaskManager::setBootDuration(double bd)
@@ -130,6 +137,13 @@ namespace sg_microserv
       ti->kill();
       delete ti;
       tiList.erase(tiList.begin() + i);
+      if (use_virtual_machines_)
+      {
+        XBT_INFO("Turn off virtual machine %s", h->get_cname());
+        dynamic_cast<VirtualMachine*>(h)->shutdown();
+        h = nullptr;
+        XBT_INFO("Done");
+      }
     }
     else
     {
@@ -142,13 +156,22 @@ namespace sg_microserv
   {
     return availableHostsList_.size();
   }
+  
   std::vector<double> ElasticTaskManager::getCPULoads()
   {
     std::vector<double> v;
     for (int i = 0; i < availableHostsList_.size(); i++)
     {
-      v.push_back(sg_host_get_avg_load(availableHostsList_.at(i)));
-      sg_host_load_reset(availableHostsList_.at(i));
+      if (use_virtual_machines_)
+      {
+        v.push_back(sg_vm_get_avg_load(availableHostsList_.at(i)));
+        sg_vm_load_reset(availableHostsList_.at(i));
+      }
+      else
+      {
+        v.push_back(sg_host_get_avg_load(availableHostsList_.at(i)));
+        sg_host_load_reset(availableHostsList_.at(i));
+      }
     }
     return v;
   }
@@ -263,7 +286,7 @@ namespace sg_microserv
     {
       tiList.at(i)->kill();
     }
-
+    XBT_INFO("Let's kill the pollers");
     for (auto a : pollers_)
     {
       a->kill();
@@ -344,9 +367,7 @@ namespace sg_microserv
     for (auto s : incMailboxes_)
     {
       Mailbox *rec = Mailbox::by_name(s.c_str());
-      pollers_.push_back(Actor::create(
-          serviceName_ + "_" + s + "polling", Host::current(), [&]
-          { pollnet(s); }));
+      pollers_.push_back(Engine::get_instance()->add_actor(serviceName_ + "_" + s + "polling", Host::current(), [&] { pollnet(s); }));
       XBT_INFO("polling on mailbox %s", s.c_str());
     }
 
@@ -366,8 +387,6 @@ namespace sg_microserv
         nextEvtQueue.pop();
         XBT_DEBUG("add: %p", currentEvent);
         TaskDescription *t = dynamic_cast<TaskDescription *>(currentEvent);
-        if (availableHostsList_.size() <= nextHost_)
-          nextHost_ = 0;
         Mailbox *mbp = Mailbox::by_name(serviceName_ + "_data");
 
         /* Async version TODO: clean pending vector */
@@ -382,9 +401,6 @@ namespace sg_microserv
         pending_comms.push_back(comm);
 
         ++task_count;
-
-        nextHost_++;
-        nextHost_ = nextHost_ % availableHostsList_.size();
       }
       if (!keepGoing)
       {

--- a/Elasticity/ElasticTask.hpp
+++ b/Elasticity/ElasticTask.hpp
@@ -19,11 +19,15 @@
 #include <xbt/string.hpp>
 #include <xbt/signal.hpp>
 #include <xbt/Extendable.hpp>
+#include "simgrid/s4u.hpp"
 #include <simgrid/s4u/Actor.hpp>
 #include <simgrid/s4u/Io.hpp>
 
 #include "ElasticConfig.hpp"
 #include "RequestType.hpp"
+
+using namespace std;
+using namespace simgrid::s4u;
 
 namespace sg_microserv {
 
@@ -245,10 +249,11 @@ class TaskInstance {
     int maxReqInInst_;
     std::vector<TaskDescription*> reqs;
     simgrid::s4u::Host* host_;
-    std::vector<simgrid::s4u::CommPtr> commV;
+    ActivitySet commV;
 
     // structures used to perform CPU executions
-    std::vector<simgrid::s4u::ExecPtr> pending_execs;
+    ActivitySet pending_execs;
+    // std::vector<simgrid::s4u::ExecPtr> pending_execs;
     std::map<simgrid::s4u::ExecPtr, TaskDescription*> execMap_;
 
     /** disk to use for I/Os and structures for pending I/O

--- a/Elasticity/ElasticTask.hpp
+++ b/Elasticity/ElasticTask.hpp
@@ -122,7 +122,6 @@ class ElasticTaskManager {
     std::string serviceName_;
     std::vector<std::string> incMailboxes_;
     bool keepGoing;
-    int nextHost_;
     double bootDuration_;
     int parallelTasksPerInst_;
 
@@ -143,6 +142,7 @@ class ElasticTaskManager {
     int64_t waitingReqAmount_;
     int64_t executingReqAmount_;
     int counterExecSlot_;
+    bool use_virtual_machines_ = false;
 
     std::vector<simgrid::s4u::ActorPtr> pollers_;
 #ifdef USE_JAEGERTRACING
@@ -153,9 +153,9 @@ class ElasticTaskManager {
 
  public:
     /* request type to string (very stupid, should be modified) */
-    ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes, std::string jaegConfigFile);
-    ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes);
-    explicit ElasticTaskManager(std::string name);
+    ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes, std::string jaegConfigFile, bool use_virtual_machines = false);
+    ElasticTaskManager(std::string name, std::vector<std::string> incMailboxes, bool use_virtual_machines = false);
+    explicit ElasticTaskManager(std::string name, bool use_virtual_machines = false);
 
     /* fetch new task requests*/
     void pollnet(std::string mbName);

--- a/Elasticity/TaskInstance.cpp
+++ b/Elasticity/TaskInstance.cpp
@@ -11,149 +11,179 @@
 
 #include "ElasticTask.hpp"
 
-// using namespace simgrid;
-// using namespace s4u;
-
 XBT_LOG_NEW_DEFAULT_CATEGORY(elasticInstance, "elastic task instance");
 
-namespace sg_microserv {
+namespace sg_microserv
+{
 
+  TaskInstance::TaskInstance(ElasticTaskManager *etm, std::string mbName,
+                             std::function<void(TaskDescription *)> outputFunction, int maxReqInInst, double bootTime)
+      : etm_(etm), mbName_(mbName), outputFunction_(outputFunction),
+        keepGoing_(true), maxReqInInst_(maxReqInInst), bootTime_(bootTime),
+        host_(nullptr)
+  {
+    n_empty_ = simgrid::s4u::Semaphore::create(maxReqInInst);
+    n_full_ = simgrid::s4u::Semaphore::create(0);
 
-TaskInstance::TaskInstance(ElasticTaskManager* etm,  std::string mbName,
-  std::function<void(TaskDescription*)> outputFunction, int maxReqInInst, double bootTime)
-  : etm_(etm), mbName_(mbName), outputFunction_(outputFunction),
-    keepGoing_(true), maxReqInInst_(maxReqInInst), bootTime_(bootTime),
-    host_(nullptr) {
-  n_empty_ = simgrid::s4u::Semaphore::create(maxReqInInst);
-  n_full_ = simgrid::s4u::Semaphore::create(0);
-
-  // atm no execs and IO so block those
-  sem_pollExec_ = simgrid::s4u::Semaphore::create(maxReqInInst_);
-  for (int i=0 ; i < maxReqInInst_ ; i++) {sem_pollExec_->acquire();}
-
-  /** if no disks are available on the host, add one in case the user wants to perform some I/O operations
-   * IMPORTANT: replaced by an exec bound for now
-   * sem_pollIO_ = s4u::Semaphore::create(maxReqInInst_);
-   * for(int i=0;i<maxReqInInst_;i++){sem_pollIO_->acquire();}
-   * if(simgrid::s4u::Host::current()->get_disks().size()){
-   * disk_ = simgrid::s4u::Host::current()->get_disks().front();
-   * XBT_DEBUG("There is already a disk ('%s') on host '%s' with bandidths R: %lf B/s, W: %lf B/s, for I/Os",
-   *   disk_->get_cname() , simgrid::s4u::Host::current()->get_cname(), disk_->get_read_bandwidth(), disk_->get_write_bandwidth());
-   * }else {
-   *
-   *  std::string diskName = "microservAutoDisk";
-   * XBT_DEBUG("No disk found on host '%s', creating one with name %s, bandwidths R: %lf B/s, W: %lf B/s for I/Os",
-   *  simgrid::s4u::Host::current()->get_cname(), diskName.c_str(), diskReadBW, diskWBW);
-   *   disk_ = simgrid::s4u::Host::current()->create_disk(diskName, 9.6e7, 6.4e7);
-   * }
-   */
-}
-
-TaskInstance::TaskInstance(ElasticTaskManager* etm, std::string mbName,
-      std::function<void(TaskDescription*)> outputFunction, int par)
-  :TaskInstance(etm, mbName, outputFunction, par, 0)
-  {}
-
-void TaskInstance::pollTasks() {
-  simgrid::s4u::Mailbox* mbp = simgrid::s4u::Mailbox::by_name(mbName_);
-
-
-  // create and init parallel reception of tasks
-  int parComSize =  maxReqInInst_;
-  XBT_DEBUG("start poll with %d parallel get_async", maxReqInInst_);
-  TaskDescription* tasksV[parComSize];
-
-  for (int i=0 ; i < parComSize ; i++) {
-    commV.push_back(mbp->get_async<TaskDescription>(&(tasksV[i])));
-  }
-
-  while (keepGoing_) {
-    int newMsgPos = simgrid::s4u::Comm::wait_any(&commV);
-    TaskDescription* taskRequest = tasksV[newMsgPos];
-    taskRequest->instArrival = simgrid::s4u::Engine::get_clock();
-    commV.erase(commV.begin()+newMsgPos);
-    commV.insert(commV.begin() + newMsgPos, mbp->get_async<TaskDescription>(&(tasksV[newMsgPos])));
-    // we wait until there is a slot to execute a task before putting the request in the slot
-    int n = n_empty_->acquire_timeout(1000);
-    if (!(n == 0))
-      continue;
-    reqs.push_back(taskRequest);
-    XBT_DEBUG("instance received a request %p at index %d, queue size: %d", taskRequest, newMsgPos, reqs.size());
-
-    n_full_->release();
-  }
-}
-
-void TaskInstance::pollEndOfTaskExec() {
-  while (keepGoing_) {
-    sem_pollExec_->acquire();
-
-    int index = simgrid::s4u::Exec::wait_any(&pending_execs);
-    // finished one exec, call output function and allow for a new execution
-    TaskDescription* td = execMap_.find(pending_execs.at(index))->second;
-    td->endExec = simgrid::s4u::Engine::get_clock();
-    etm_->modifExecutingReqAmount(-1);
-    etm_->setCounterExecSlot(etm_->getCounterExecSlot()+1);
-
-#ifdef USE_JAEGERTRACING
-        auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(
-            static_cast<int>(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-        // Check if no problem on spans
-        if (td->parentSpans.size() > 0)
-          td->parentSpans.at(td->parentSpans.size()-1)->get()->Log(
-            {{"endExec", simgrid::s4u::Engine::get_instance()->get_clock()}});
-#endif
-
-    // remove execPtr from the vector since it finished
-    simgrid::s4u::ExecPtr ep = pending_execs.at(index);
-    pending_execs.erase(pending_execs.begin()+index);
-
-    XBT_DEBUG("End of execution for %p, call output function", td);
-    simgrid::s4u::ActorPtr out = simgrid::s4u::Actor::create(
-      mbName_+"outputf"+boost::uuids::to_string(uuidGen_()), simgrid::s4u::Host::current(), [&]{outputFunction_(td);});
-    if (keepGoing_)n_empty_->release();
+    // atm no execs and IO so block those
+    sem_pollExec_ = simgrid::s4u::Semaphore::create(maxReqInInst_);
+    for (int i = 0; i < maxReqInInst_; i++)
+    {
+      sem_pollExec_->acquire();
     }
-}
 
-void TaskInstance::run() {
-  host_ = simgrid::s4u::this_actor::get_host();
+    /** if no disks are available on the host, add one in case the user wants to perform some I/O operations
+     * IMPORTANT: replaced by an exec bound for now
+     * sem_pollIO_ = s4u::Semaphore::create(maxReqInInst_);
+     * for(int i=0;i<maxReqInInst_;i++){sem_pollIO_->acquire();}
+     * if(simgrid::s4u::Host::current()->get_disks().size()){
+     * disk_ = simgrid::s4u::Host::current()->get_disks().front();
+     * XBT_DEBUG("There is already a disk ('%s') on host '%s' with bandidths R: %lf B/s, W: %lf B/s, for I/Os",
+     *   disk_->get_cname() , simgrid::s4u::Host::current()->get_cname(), disk_->get_read_bandwidth(), disk_->get_write_bandwidth());
+     * }else {
+     *
+     *  std::string diskName = "microservAutoDisk";
+     * XBT_DEBUG("No disk found on host '%s', creating one with name %s, bandwidths R: %lf B/s, W: %lf B/s for I/Os",
+     *  simgrid::s4u::Host::current()->get_cname(), diskName.c_str(), diskReadBW, diskWBW);
+     *   disk_ = simgrid::s4u::Host::current()->create_disk(diskName, 9.6e7, 6.4e7);
+     * }
+     */
+  }
 
-  poll = simgrid::s4u::Actor::create(
-    mbName_+boost::uuids::to_string(uuidGen_()), simgrid::s4u::Host::current(), [&]{pollTasks();});
-  pollEnd = simgrid::s4u::Actor::create(mbName_+"pollEnd",
-    simgrid::s4u::Host::current(), [&]{pollEndOfTaskExec();});
-  // boot duration (just sleep so that we don't process any request in the node until bootime elapsed)
-  simgrid::s4u::this_actor::sleep_for(bootTime_);
+  TaskInstance::TaskInstance(ElasticTaskManager *etm, std::string mbName,
+                             std::function<void(TaskDescription *)> outputFunction, int par)
+      : TaskInstance(etm, mbName, outputFunction, par, 0)
+  {
+  }
 
-  while (keepGoing_) {
-    try {
-      int n = n_full_->acquire_timeout(1000);
-      if (!(n == 0))
-        continue;
+  void TaskInstance::pollTasks()
+  {
+    simgrid::s4u::Mailbox *mbp = simgrid::s4u::Mailbox::by_name(mbName_);
 
-      if (reqs.size() == 0) {
+    // create and init parallel reception of tasks
+    int parComSize = maxReqInInst_;
+    XBT_DEBUG("start poll with %d parallel get_async", maxReqInInst_);
+    std::unordered_map<CommPtr, std::shared_ptr<TaskDescription *>> pending_msgs;
+
+    for (int i = 0; i < parComSize; i++)
+    {
+      auto msg = std::make_shared<TaskDescription *>();
+      auto comm = mbp->get_async<TaskDescription>(msg.get());
+      commV.push(comm);
+      pending_msgs.insert({comm, msg});
+    }
+
+    while (keepGoing_)
+    {
+      auto newMsgPos = commV.wait_any();
+      if (newMsgPos == nullptr)
+      {
         continue;
       }
-      // receive data from mailbox
-      TaskDescription* td = reqs.at(0);
-      td->startExec = simgrid::s4u::Engine::get_clock();
-      reqs.erase(reqs.begin());
-      XBT_DEBUG("instance received req %p", td);
+      auto comm = boost::dynamic_pointer_cast<Comm>(newMsgPos);
+      TaskDescription *taskRequest = *pending_msgs[comm];
+      pending_msgs.erase(comm);
+
+      taskRequest->instArrival = simgrid::s4u::Engine::get_clock();
+
+      auto msg = std::make_shared<TaskDescription *>();
+      auto newcomm = mbp->get_async<TaskDescription>(msg.get());
+      commV.push(newcomm);
+      pending_msgs.insert({newcomm, msg});
+
+      // we wait until there is a slot to execute a task before putting the request in the slot
+      int n = n_empty_->acquire_timeout(1000);
+      if (!(n == 0))
+        continue;
+      reqs.push_back(taskRequest);
+      XBT_DEBUG("instance received a request %p, queue size: %ld", taskRequest, reqs.size());
+
+      n_full_->release();
+    }
+  }
+
+  void TaskInstance::pollEndOfTaskExec()
+  {
+    while (keepGoing_)
+    {
+      sem_pollExec_->acquire();
+
+      auto newMsgPos = pending_execs.wait_any();
+      if (newMsgPos == nullptr)
+      {
+        continue;
+      }
+      auto exec = boost::dynamic_pointer_cast<Exec>(newMsgPos);
+      // finished one exec, call output function and allow for a new execution
+      TaskDescription *td = execMap_.find(exec)->second;
+      td->endExec = simgrid::s4u::Engine::get_clock();
+      etm_->modifExecutingReqAmount(-1);
+      etm_->setCounterExecSlot(etm_->getCounterExecSlot() + 1);
+
+#ifdef USE_JAEGERTRACING
+      auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(
+                                                      static_cast<int>(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+      // Check if no problem on spans
+      if (td->parentSpans.size() > 0)
+        td->parentSpans.at(td->parentSpans.size() - 1)->get()->Log({{"endExec", simgrid::s4u::Engine::get_instance()->get_clock()}});
+#endif
+
+      // remove execPtr from the vector since it finished
+      simgrid::s4u::ExecPtr ep = exec;
+
+      XBT_DEBUG("End of execution for %p, call output function", td);
+      simgrid::s4u::ActorPtr out = simgrid::s4u::Actor::create(
+          mbName_ + "outputf" + boost::uuids::to_string(uuidGen_()), simgrid::s4u::Host::current(), [&]
+          { outputFunction_(td); });
+      if (keepGoing_)
+        n_empty_->release();
+    }
+  }
+
+  void TaskInstance::run()
+  {
+    host_ = simgrid::s4u::this_actor::get_host();
+
+    poll = simgrid::s4u::Actor::create(
+        mbName_ + boost::uuids::to_string(uuidGen_()), simgrid::s4u::Host::current(), [&]
+        { pollTasks(); });
+    pollEnd = simgrid::s4u::Actor::create(mbName_ + "pollEnd",
+                                          simgrid::s4u::Host::current(), [&]
+                                          { pollEndOfTaskExec(); });
+    // boot duration (just sleep so that we don't process any request in the node until bootime elapsed)
+    simgrid::s4u::this_actor::sleep_for(bootTime_);
+
+    while (keepGoing_)
+    {
+      try
+      {
+        int n = n_full_->acquire_timeout(1000);
+        if (!(n == 0))
+          continue;
+
+        if (reqs.size() == 0)
+        {
+          continue;
+        }
+        // receive data from mailbox
+        TaskDescription *td = reqs.at(0);
+        td->startExec = simgrid::s4u::Engine::get_clock();
+        reqs.erase(reqs.begin());
+        XBT_DEBUG("instance received req %p", td);
 #ifdef USE_JAEGERTRACING
         std::string rName = etm_->getStrFromReqType(td->requestType);
-        auto t1 = std::chrono::seconds(946684800)+std::chrono::microseconds(
-            static_cast<int>(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-        auto span = td->parentSpans.size() == 0?
-          etm_->getTracer().get()->StartSpan(rName,
-            {opentracing::v3::StartTimestamp(t1)}) :
-          etm_->getTracer().get()->StartSpan(rName,
-            {opentracing::v3::StartTimestamp(t1), opentracing::v3::ChildOf(
-              &td->parentSpans.at(td->parentSpans.size()-1)->get()->context())});
-        span->Log({ {"nbInst:", etm_->getInstanceAmount()},
-          {"waitingReqAtStart:", etm_->getAmountOfWaitingRequests()},
-          {"alreadyExecutingAtStart:", etm_->getAmountOfExecutingRequests()},
-          {"startExec", simgrid::s4u::Engine::get_instance()->get_clock()}});
-        std::unique_ptr<opentracing::v3::Span>* t = new std::unique_ptr<opentracing::v3::Span>();
+        auto t1 = std::chrono::seconds(946684800) + std::chrono::microseconds(
+                                                        static_cast<int>(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+        auto span = td->parentSpans.size() == 0 ? etm_->getTracer().get()->StartSpan(rName,
+                                                                                     {opentracing::v3::StartTimestamp(t1)})
+                                                : etm_->getTracer().get()->StartSpan(rName,
+                                                                                     {opentracing::v3::StartTimestamp(t1), opentracing::v3::ChildOf(
+                                                                                                                               &td->parentSpans.at(td->parentSpans.size() - 1)->get()->context())});
+        span->Log({{"nbInst:", etm_->getInstanceAmount()},
+                   {"waitingReqAtStart:", etm_->getAmountOfWaitingRequests()},
+                   {"alreadyExecutingAtStart:", etm_->getAmountOfExecutingRequests()},
+                   {"startExec", simgrid::s4u::Engine::get_instance()->get_clock()}});
+        std::unique_ptr<opentracing::v3::Span> *t = new std::unique_ptr<opentracing::v3::Span>();
         *t = std::move(span);
         td->parentSpans.push_back(t);
 #endif
@@ -178,7 +208,7 @@ void TaskInstance::run() {
         else
           boundValue = simgrid::s4u::this_actor::get_host()->get_speed();
         XBT_DEBUG("Start execution of request. Flops: %lf, Ratio: %lf, CPUBound: %lf/%lf",
-          realToBeExecuted, execRatio, boundValue, simgrid::s4u::this_actor::get_host()->get_speed());
+                  realToBeExecuted, execRatio, boundValue, simgrid::s4u::this_actor::get_host()->get_speed());
 
         /* don't launch it directly since we want to set a bound*/
         simgrid::s4u::ExecPtr execP = simgrid::s4u::this_actor::exec_init(realToBeExecuted);
@@ -188,36 +218,41 @@ void TaskInstance::run() {
 
         // append the execPTr to the exec vector of executing requests,
         // it will be handled in the endExec polling actor once finished
-        pending_execs.push_back(execP);
-        execMap_.insert(std::pair<simgrid::s4u::ExecPtr, TaskDescription*>(execP, td));
+        pending_execs.push(execP);
+        execMap_.insert(std::pair<simgrid::s4u::ExecPtr, TaskDescription *>(execP, td));
 
         // allow the pollEnds to execute
         sem_pollExec_->release();
-    } catch (std::exception e) {XBT_INFO("woops: %s", e.what());}
-  }
-}
-
-void TaskInstance::kill() {
-  XBT_INFO("Kill taskinstance td size: %d %d", reqs.size(), execMap_.size());
-
-  keepGoing_ = false;
-  // don't receive requests anymore
-  // simgrid::s4u::Comm::wait_all(&commV);
-  for (auto c : commV) {
-    c->cancel();
+      }
+      catch (std::exception e)
+      {
+        XBT_INFO("woops: %s", e.what());
+      }
+    }
   }
 
-  // I GUESS IT IS NOT THE WAY TO DO
-  // IF WE KILL THE INSTANCE BUT SOME EXEC_ASYNC ARE STILL EXECUTING
-  // WAIT FOR THE LAST ONE TO FINISH
-  // IT SEEMS TO AVOID A SEGFAULT IN THE HOSTLOAD PLUGIN, BUT ITS A HORRIBLE WAY TO DO IT I GUESS
-  if (pending_execs.size() > 0)
-    pending_execs.at(pending_execs.size()-1)->wait();
+  void TaskInstance::kill()
+  {
+    XBT_INFO("Kill taskinstance td size: %ld %ld", reqs.size(), execMap_.size());
 
-  poll->kill();
-  pollEnd->kill();
-  n_empty_->release();
-  n_full_->release();
-  sem_pollExec_->release();
-}
-}  // namespace sg_microserv
+    keepGoing_ = false;
+    // don't receive requests anymore
+    // simgrid::s4u::Comm::wait_all(&commV);
+    // for (auto c : commV) {
+    //   c->cancel();
+    // }
+
+    // I GUESS IT IS NOT THE WAY TO DO
+    // IF WE KILL THE INSTANCE BUT SOME EXEC_ASYNC ARE STILL EXECUTING
+    // WAIT FOR THE LAST ONE TO FINISH
+    // IT SEEMS TO AVOID A SEGFAULT IN THE HOSTLOAD PLUGIN, BUT ITS A HORRIBLE WAY TO DO IT I GUESS
+    if (pending_execs.size() > 0)
+      pending_execs.at(pending_execs.size() - 1)->wait();
+
+    poll->kill();
+    pollEnd->kill();
+    n_empty_->release();
+    n_full_->release();
+    sem_pollExec_->release();
+  }
+} // namespace sg_microserv

--- a/Elasticity/TaskInstance.cpp
+++ b/Elasticity/TaskInstance.cpp
@@ -121,20 +121,21 @@ namespace sg_microserv
       etm_->setCounterExecSlot(etm_->getCounterExecSlot() + 1);
 
 #ifdef USE_JAEGERTRACING
-      auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(
-                                                      static_cast<int>(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
       // Check if no problem on spans
       if (td->parentSpans.size() > 0)
         td->parentSpans.at(td->parentSpans.size() - 1)->get()->Log({{"endExec", simgrid::s4u::Engine::get_instance()->get_clock()}});
+// #else
+//       XBT_INFO("Task arrival %f Start execution %f End %f", td->firstArrivalDate, td->startExec, td->endExec);
 #endif
 
       // remove execPtr from the vector since it finished
       simgrid::s4u::ExecPtr ep = exec;
 
       XBT_DEBUG("End of execution for %p, call output function", td);
-      simgrid::s4u::ActorPtr out = simgrid::s4u::Actor::create(
-          mbName_ + "outputf" + boost::uuids::to_string(uuidGen_()), simgrid::s4u::Host::current(), [&]
-          { outputFunction_(td); });
+      simgrid::s4u::ActorPtr out = simgrid::s4u::Engine::get_instance()->add_actor(mbName_ + "outputf" + boost::uuids::to_string(uuidGen_()),
+                                                                                   simgrid::s4u::Host::current(),
+                                                                                   [&]
+                                                                                   { outputFunction_(td); });
       if (keepGoing_)
         n_empty_->release();
     }
@@ -143,13 +144,15 @@ namespace sg_microserv
   void TaskInstance::run()
   {
     host_ = simgrid::s4u::this_actor::get_host();
-
-    poll = simgrid::s4u::Actor::create(
-        mbName_ + boost::uuids::to_string(uuidGen_()), simgrid::s4u::Host::current(), [&]
-        { pollTasks(); });
-    pollEnd = simgrid::s4u::Actor::create(mbName_ + "pollEnd",
-                                          simgrid::s4u::Host::current(), [&]
-                                          { pollEndOfTaskExec(); });
+    string name = mbName_ + boost::uuids::to_string(uuidGen_());
+    poll = simgrid::s4u::Engine::get_instance()->add_actor(name + "_polltasks",
+                                                           simgrid::s4u::Host::current(),
+                                                           [&]
+                                                           { pollTasks(); });
+    pollEnd = simgrid::s4u::Engine::get_instance()->add_actor(name + "_pollend",
+                                                              simgrid::s4u::Host::current(),
+                                                              [&]
+                                                              { pollEndOfTaskExec(); });
     // boot duration (just sleep so that we don't process any request in the node until bootime elapsed)
     simgrid::s4u::this_actor::sleep_for(bootTime_);
 
@@ -254,5 +257,6 @@ namespace sg_microserv
     n_empty_->release();
     n_full_->release();
     sem_pollExec_->release();
+    XBT_INFO("Finished killing %s", this->mbName_.c_str());
   }
 } // namespace sg_microserv

--- a/Elasticity/TaskInstance.cpp
+++ b/Elasticity/TaskInstance.cpp
@@ -236,8 +236,6 @@ namespace sg_microserv
 
   void TaskInstance::kill()
   {
-    XBT_INFO("Kill taskinstance td size: %ld %ld", reqs.size(), execMap_.size());
-
     keepGoing_ = false;
     // don't receive requests anymore
     // simgrid::s4u::Comm::wait_all(&commV);
@@ -257,6 +255,5 @@ namespace sg_microserv
     n_empty_->release();
     n_full_->release();
     sem_pollExec_->release();
-    XBT_INFO("Finished killing %s", this->mbName_.c_str());
   }
 } // namespace sg_microserv

--- a/Elasticity/WriteBuffer.cpp
+++ b/Elasticity/WriteBuffer.cpp
@@ -1,0 +1,66 @@
+#include "WriteBuffer.hpp"
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(writter, "WriteBuffer"); //!< Logging
+
+WriteBuffer::WriteBuffer(const std::string & filename, size_t buffer_size)
+    : buffer_size(buffer_size)
+{
+    xbt_assert(buffer_size > 0, "Invalid buffer size (%zu)", buffer_size);
+    buffer = new char[buffer_size];
+
+    f.open(filename, ios_base::trunc);
+    xbt_assert(f.is_open(), "Cannot write file '%s'", filename.c_str());
+}
+
+WriteBuffer::~WriteBuffer()
+{
+    if (buffer_pos > 0)
+    {
+        flush_buffer();
+    }
+
+    if (buffer != nullptr)
+    {
+        delete[] buffer;
+        buffer = nullptr;
+
+        f.close();
+    }
+}
+
+void WriteBuffer::append_text(const char * text)
+{
+    const size_t text_length = strlen(text);
+
+    // Is the buffer big enough?
+    if (buffer_pos + text_length < buffer_size)
+    {
+        // Append the text into the buffer
+        memcpy(buffer + buffer_pos, text, text_length * sizeof(char));
+        buffer_pos += text_length;
+    }
+    else
+    {
+        // Write the current buffer content in the file
+        flush_buffer();
+
+        // Does the text fit in the (now empty) buffer?
+        if (text_length < buffer_size)
+        {
+            // Copy the text into the buffer
+            memcpy(buffer, text, text_length * sizeof(char));
+            buffer_pos = text_length;
+        }
+        else
+        {
+            // Directly write the text into the file
+            f.write(text, static_cast<std::streamsize>(text_length));
+        }
+    }
+}
+
+void WriteBuffer::flush_buffer()
+{
+    f.write(buffer, static_cast<std::streamsize>(buffer_pos));
+    buffer_pos = 0;
+}

--- a/Elasticity/WriteBuffer.hpp
+++ b/Elasticity/WriteBuffer.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <stdio.h>
+#include <string>
+#include <fstream>
+#include <simgrid/s4u.hpp>
+#include "xbt/replay.hpp"
+
+using namespace simgrid::s4u;
+using namespace std;
+
+/**
+ * @brief Buffered-write output file
+ */
+class WriteBuffer
+{
+public:
+    /**
+     * @brief Builds a WriteBuffer
+     * @param[in] filename The file that will be written
+     * @param[in] buffer_size The size of the buffer (in bytes).
+     */
+    explicit WriteBuffer(const std::string & filename,
+                         size_t buffer_size = 64*1024);
+
+    /**
+     * @brief WriteBuffers cannot be copied.
+     * @param[in] other Another instance
+     */
+    WriteBuffer(const WriteBuffer & other) = delete;
+
+    /**
+     * @brief Destructor
+     * @details This method flushes the buffer if it is not empty, destroys the buffer and closes the file.
+     */
+    ~WriteBuffer();
+
+    /**
+     * @brief Appends a text at the end of the buffer. If the buffer is full, it is automatically flushed into the disk.
+     * @param[in] text The text to append
+     */
+    void append_text(const char * text);
+
+    /**
+     * @brief Write the current content of the buffer into the file
+     */
+    void flush_buffer();
+
+private:
+    std::ofstream f;            //!< The file stream on which the buffer is outputted
+    const size_t buffer_size;   //!< The buffer maximum size
+    char * buffer = nullptr;    //!< The buffer
+    size_t buffer_pos = 0;         //!< The current position of the buffer (previous positions are already written)
+};

--- a/Readme.org
+++ b/Readme.org
@@ -24,6 +24,17 @@ the examples before running them using the benchmark scripts we provide.
 The code of our microservice model can be found in [[./Elasticity]], and the code of
 the simulators in [[./example]].
 
+You can use NixOS to install the dependencies. The majority of the dependencies are 
+listed in the default.nix file (all dependencies but Jaeger). 
+
+With NixOS installed, it is necessary to run the following command inside the main folder:
+
+#+BEGIN_SRC sh
+nix-shell
+#+END_SRC
+
+This command downloads and installs the dependencies in the right version to run the simulation.
+
 Our simulators are able to export simulated traces to Jaeger thanks to an
 opentracing instrumentation. To use this feature you need
 https://github.com/jaegertracing/jaeger-client-cpp.

--- a/config_files/platforms/two_hosts_100p_10c.xml
+++ b/config_files/platforms/two_hosts_100p_10c.xml
@@ -3,8 +3,12 @@
 <platform version="4.1">
   <zone id="world" routing="Full">
     <!-- The resources -->
-    <host id="clemth.irisa.fr" speed="1Gf" core="10"/>
-    <host id="clempc" speed="1Gf" core="10"/>
+    <host id="clemth.irisa.fr" speed="1Gf" core="10">
+      <prop id="wattage_per_state" value="62.0:62.0:143.4"/>
+    </host>
+    <host id="clempc" speed="1Gf" core="10">
+      <prop id="wattage_per_state" value="62.0:62.0:143.4"/>
+    </host>
     <link id="1" bandwidth="125GBps" latency="0us"/>
 
     <!-- The routing between resources -->

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{
+  pkgs ? import (fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296.tar.gz";
+    sha256 = "1gx0hihb7kcddv5h0k7dysp2xhf1ny0aalxhjbpj2lmvj7h9g80a";
+  }) {}
+}:
+pkgs.stdenv.mkDerivation rec {
+  pname = "simgrid-test";
+  version = "0.1.0";
+
+  buildInputs = [
+    pkgs.cmake
+    pkgs.boost
+    pkgs.simgrid
+    pkgs.nlohmann_json
+    pkgs.gdb
+  ];
+
+}

--- a/default.nix
+++ b/default.nix
@@ -8,10 +8,10 @@
 let 
   simgrid = pkgs.simgrid.overrideAttrs(oldAttrs: rec {
   version = oldAttrs.version + "-vm_load";
-  rev = "b2e72d6b597494e29ef3471073fb5a8c2e3e563c"; # The desired SimGrid commit.
+  rev = "ac8abcab3c51fb82368c53f21bcb037b7920ed0a"; # The desired SimGrid commit.
   src = pkgs.fetchurl {
-    url = "https://github.com/igornardin/simgrid/archive/refs/tags/v1.0.tar.gz";
-    sha256 = "sha256-gVTkq3IwYwwfHhFsnetVlPZJYgrN6b6COl/v6SmudEs=";
+    url = "https://github.com/igornardin/simgrid/archive/refs/tags/V1.1.tar.gz";
+    sha256 = "sha256-8OazbLzSM04mBOkU6LPuy2I7JaNIiUTrsK/VautVJ78=";
   };
 });
 

--- a/default.nix
+++ b/default.nix
@@ -4,16 +4,32 @@
     sha256 = "1gx0hihb7kcddv5h0k7dysp2xhf1ny0aalxhjbpj2lmvj7h9g80a";
   }) {}
 }:
-pkgs.stdenv.mkDerivation rec {
-  pname = "simgrid-test";
+
+let 
+  simgrid = pkgs.simgrid.overrideAttrs(oldAttrs: rec {
+  version = oldAttrs.version + "-vm_load";
+  rev = "b2e72d6b597494e29ef3471073fb5a8c2e3e563c"; # The desired SimGrid commit.
+  src = pkgs.fetchurl {
+    url = "https://github.com/igornardin/simgrid/archive/refs/tags/v1.0.tar.gz";
+    sha256 = "sha256-gVTkq3IwYwwfHhFsnetVlPZJYgrN6b6COl/v6SmudEs=";
+  };
+});
+
+in pkgs.stdenv.mkDerivation rec {
+  pname = "Microservices_simgrid";
   version = "0.1.0";
 
   buildInputs = [
     pkgs.cmake
     pkgs.boost
-    pkgs.simgrid
+    simgrid
     pkgs.nlohmann_json
     pkgs.gdb
+    pkgs.python312
+    pkgs.python312Packages.networkx
+    pkgs.python312Packages.graphviz
+    pkgs.python312Packages.pygraphviz
+    pkgs.python312Packages.pandas
   ];
 
 }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,15 +2,18 @@
 # Search for SimGrid
 include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 INCLUDE_DIRECTORIES(../Elasticity)
-INCLUDE_DIRECTORIES(SYSTEM /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/include)
-LINK_DIRECTORIES(
-  /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/lib
-  ~/Code/framagit.org/simgridOfficiel/simgrid//build3.27/lib)
+
+# INCLUDE_DIRECTORIES(SYSTEM /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/include)
+# LINK_DIRECTORIES(
+#   /home/clem/.hunter/_Base/d45d77d/4430a64/3b7ee27/Install/lib
+#   ~/Code/framagit.org/simgridOfficiel/simgrid//build3.27/lib)
 
 if(USE_JAEGERTRACING)
   list(APPEND EXTRA_LIBS  jaegertracing opentracing yaml-cppd)
-
 endif()
 
 FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../Elasticity/config.yml

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,3 +42,6 @@ TARGET_LINK_LIBRARIES(teastore_login Elasticity simgrid ${EXTRA_LIBS})
 
 ADD_EXECUTABLE(generated_2inst generated_2inst.cpp )
 TARGET_LINK_LIBRARIES(generated_2inst Elasticity simgrid ${EXTRA_LIBS})
+
+ADD_EXECUTABLE(DSB DSB.cpp )
+TARGET_LINK_LIBRARIES(DSB Elasticity simgrid ${EXTRA_LIBS})

--- a/examples/DSB.cpp
+++ b/examples/DSB.cpp
@@ -1,0 +1,1089 @@
+
+#include <simgrid/s4u/Actor.hpp>
+#include <simgrid/s4u/Host.hpp>
+#include <simgrid/s4u/Mailbox.hpp>
+#include <simgrid/s4u/Engine.hpp>
+#include <simgrid/s4u/Comm.hpp>
+#include "ElasticPolicy.hpp"
+#include "simgrid/s4u.hpp"
+#include "ElasticTask.hpp"
+#include "DataSource.hpp"
+#include <memory>
+#include "WriteBuffer.hpp"
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(run_log, "logs of the experiment");
+
+using namespace sg_microserv;
+
+WriteBuffer *calls_csv = nullptr;
+
+int outSizes(RequestType, std::string);
+/* RETURN FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
+void return_nginx_web_server(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service nginx_web_server");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 1)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+   }
+}
+void return_compose_post_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service compose_post_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 2)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to unique_id_service");
+         s4u_Mailbox *m_unique_id_service = s4u_Mailbox::by_name("unique_id_service");
+         m_unique_id_service->put(td, outSizes(td->requestType, "unique_id_service"));
+
+         break;
+      }
+
+      if (td->nbHops == 4)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to media_service");
+         s4u_Mailbox *m_media_service = s4u_Mailbox::by_name("media_service");
+         m_media_service->put(td, outSizes(td->requestType, "media_service"));
+
+         break;
+      }
+
+      if (td->nbHops == 6)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to user_service");
+         s4u_Mailbox *m_user_service = s4u_Mailbox::by_name("user_service");
+         m_user_service->put(td, outSizes(td->requestType, "user_service"));
+
+         break;
+      }
+
+      if (td->nbHops == 8)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to text_service");
+         s4u_Mailbox *m_text_service = s4u_Mailbox::by_name("text_service");
+         m_text_service->put(td, outSizes(td->requestType, "text_service"));
+
+         break;
+      }
+
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 12)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to home_timeline_service");
+         s4u_Mailbox *m_home_timeline_service = s4u_Mailbox::by_name("home_timeline_service");
+         m_home_timeline_service->put(td, outSizes(td->requestType, "home_timeline_service"));
+
+         break;
+      }
+
+      if (td->nbHops == 16)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to user_timeline_service");
+         s4u_Mailbox *m_user_timeline_service = s4u_Mailbox::by_name("user_timeline_service");
+         m_user_timeline_service->put(td, outSizes(td->requestType, "user_timeline_service"));
+
+         break;
+      }
+
+      if (td->nbHops == 18)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to post_storage_service");
+         s4u_Mailbox *m_post_storage_service = s4u_Mailbox::by_name("post_storage_service");
+         m_post_storage_service->put(td, outSizes(td->requestType, "post_storage_service"));
+
+         break;
+      }
+
+      break;
+   }
+}
+void return_unique_id_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service unique_id_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 3)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+   }
+}
+void return_media_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service media_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 5)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+   }
+}
+void return_user_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service user_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 7)
+      {
+         XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+   }
+}
+void return_text_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service text_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 9)
+      {
+         XBT_DEBUG("Output Function for text_service (PARALLEL CHILDS)");
+         ActivitySet commV;
+         simgrid::s4u::CommPtr com;
+
+         XBT_DEBUG("Put to text_service");
+         s4u_Mailbox *m_text_service = s4u_Mailbox::by_name("text_service");
+         TaskDescription *td_0 = new TaskDescription(*td);
+         td_0->requestType = RequestType::COMPOSE_0;
+         com = m_text_service->put_async(td_0, outSizes(td_0->requestType, "text_service"));
+         commV.push(com);
+
+         XBT_DEBUG("Put to text_service");
+         s4u_Mailbox *m_text_service_ = s4u_Mailbox::by_name("text_service");
+         TaskDescription *td_1 = new TaskDescription(*td);
+         td_1->requestType = RequestType::COMPOSE_1;
+         com = m_text_service_->put_async(td_1, outSizes(td_1->requestType, "text_service"));
+         commV.push(com);
+         commV.wait_all();
+         delete td;
+         break;
+      }
+
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 10)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to user_mention_service");
+         s4u_Mailbox *m_user_mention_service = s4u_Mailbox::by_name("user_mention_service");
+         m_user_mention_service->put(td, outSizes(td->requestType, "user_mention_service"));
+
+         break;
+      }
+
+      break;
+
+   case RequestType::COMPOSE_1:
+      if (td->nbHops == 10)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_1, put to url_shorten_service");
+         s4u_Mailbox *m_url_shorten_service = s4u_Mailbox::by_name("url_shorten_service");
+         m_url_shorten_service->put(td, outSizes(td->requestType, "url_shorten_service"));
+
+         break;
+      }
+
+      break;
+   }
+}
+void return_user_mention_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service user_mention_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 11)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+
+      break;
+   }
+}
+void return_home_timeline_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service home_timeline_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 13)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to social_graph_service");
+         s4u_Mailbox *m_social_graph_service = s4u_Mailbox::by_name("social_graph_service");
+         m_social_graph_service->put(td, outSizes(td->requestType, "social_graph_service"));
+
+         break;
+      }
+
+      if (td->nbHops == 15)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+
+      break;
+   }
+}
+void return_social_graph_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service social_graph_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 14)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to home_timeline_service");
+         s4u_Mailbox *m_home_timeline_service = s4u_Mailbox::by_name("home_timeline_service");
+         m_home_timeline_service->put(td, outSizes(td->requestType, "home_timeline_service"));
+
+         break;
+      }
+
+      break;
+   }
+}
+void return_user_timeline_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service user_timeline_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 17)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
+         s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+         m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+         break;
+      }
+
+      break;
+   }
+}
+void return_post_storage_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service post_storage_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+#ifdef USE_JAEGERTRACING
+      if (td->nbHops == 19)
+      {
+         XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock() - td->firstArrivalDate);
+         XBT_DEBUG("Output Function for COMPOSE_0, Final service, DELETE");
+         for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+         {
+            if ((*it)->get() != NULL)
+            {
+               auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+               (*it)->get()->Log({{"end", t2.count()}});
+               (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+               (*it)->reset();
+               (*it) == NULL;
+            }
+         }
+         delete td;
+      }
+#else
+      if (td->nbHops == 19)
+      {
+         calls_csv->append_text(to_string(td->firstArrivalDate).c_str());
+         calls_csv->append_text(",");
+         calls_csv->append_text(to_string(simgrid::s4u::Engine::get_clock()).c_str());
+         calls_csv->append_text(",");
+         calls_csv->append_text(to_string(simgrid::s4u::Engine::get_clock() - td->firstArrivalDate).c_str());
+         calls_csv->append_text("\n");
+         delete td;
+      }
+#endif /*USE_JAEGERTRACING*/
+      break;
+   }
+}
+void return_url_shorten_service(TaskDescription *td)
+{
+   XBT_DEBUG("Return function of service url_shorten_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_1:
+#ifdef USE_JAEGERTRACING
+      if (td->nbHops == 11)
+      {
+         XBT_DEBUG("Output Function for COMPOSE_1, Final service, DELETE");
+         for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+         {
+            if ((*it)->get() != NULL)
+            {
+               auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+               (*it)->get()->Log({{"end", t2.count()}});
+               (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+               (*it)->reset();
+               (*it) == NULL;
+            }
+         }
+         delete td;
+      }
+#else
+      if (td->nbHops == 11)
+      {
+         delete td;
+      }      
+#endif /*USE_JAEGERTRACING*/
+      break;
+   }
+}
+/* PR FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
+double pr_nginx_web_server(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service nginx_web_server");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 1)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 500000;
+      }
+   } // it should never end up here
+   return -1;
+}
+double pr_compose_post_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service compose_post_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 2)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 608000;
+      }
+
+      if (td->nbHops == 4)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 118000;
+      }
+
+      if (td->nbHops == 6)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 117000;
+      }
+
+      if (td->nbHops == 8)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 134000;
+      }
+
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 12)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 264000;
+      }
+
+      if (td->nbHops == 16)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 173000;
+      }
+
+      if (td->nbHops == 18)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 288000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_unique_id_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service unique_id_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 3)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 11000;
+      }
+   } // it should never end up here
+   return -1;
+}
+double pr_media_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service media_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 5)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 6000;
+      }
+   } // it should never end up here
+   return -1;
+}
+double pr_user_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service user_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 7)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE");
+         return 5000;
+      }
+   } // it should never end up here
+   return -1;
+}
+double pr_text_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service text_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE:
+      if (td->nbHops == 9)
+      {
+         XBT_DEBUG("Entered cost Function for text_service");
+         return 318000;
+      }
+      break;
+
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 10)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 159000;
+      }
+
+      break;
+
+   case RequestType::COMPOSE_1:
+      if (td->nbHops == 10)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_1");
+         return 457000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_user_mention_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service user_mention_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 11)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 724000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_home_timeline_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service home_timeline_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 13)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 168000;
+      }
+
+      if (td->nbHops == 15)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 5000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_social_graph_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service social_graph_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 14)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 707000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_user_timeline_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service user_timeline_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 17)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0");
+         return 834000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_post_storage_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service post_storage_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_0:
+      if (td->nbHops == 19)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_0 (FINAL NODE, NO CHILD!)");
+         return 508000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+double pr_url_shorten_service(TaskDescription *td)
+{
+   XBT_DEBUG("pr function of service url_shorten_service");
+   switch (td->requestType)
+   {
+   case RequestType::COMPOSE_1:
+      if (td->nbHops == 11)
+      {
+         XBT_DEBUG("Entered cost Function for COMPOSE_1 (FINAL NODE, NO CHILD!)");
+         return 451000;
+      }
+
+      break;
+   } // it should never end up here
+   return -1;
+}
+int outSizes(RequestType t, std::string nextServ)
+{
+   switch (t)
+   {
+   case RequestType::COMPOSE:
+      if (nextServ == "compose_post_service")
+      {
+         return 100;
+      }
+      if (nextServ == "unique_id_service")
+      {
+         return 100;
+      }
+      if (nextServ == "media_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_service")
+      {
+         return 100;
+      }
+      if (nextServ == "text_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_mention_service")
+      {
+         return 100;
+      }
+      if (nextServ == "home_timeline_service")
+      {
+         return 100;
+      }
+      if (nextServ == "social_graph_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_timeline_service")
+      {
+         return 100;
+      }
+      if (nextServ == "post_storage_service")
+      {
+         return 100;
+      }
+      if (nextServ == "url_shorten_service")
+      {
+         return 100;
+      }
+      break;
+   case RequestType::COMPOSE_0:
+      if (nextServ == "compose_post_service")
+      {
+         return 100;
+      }
+      if (nextServ == "unique_id_service")
+      {
+         return 100;
+      }
+      if (nextServ == "media_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_service")
+      {
+         return 100;
+      }
+      if (nextServ == "text_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_mention_service")
+      {
+         return 100;
+      }
+      if (nextServ == "home_timeline_service")
+      {
+         return 100;
+      }
+      if (nextServ == "social_graph_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_timeline_service")
+      {
+         return 100;
+      }
+      if (nextServ == "post_storage_service")
+      {
+         return 100;
+      }
+      if (nextServ == "url_shorten_service")
+      {
+         return 100;
+      }
+      break;
+   case RequestType::COMPOSE_1:
+      if (nextServ == "compose_post_service")
+      {
+         return 100;
+      }
+      if (nextServ == "unique_id_service")
+      {
+         return 100;
+      }
+      if (nextServ == "media_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_service")
+      {
+         return 100;
+      }
+      if (nextServ == "text_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_mention_service")
+      {
+         return 100;
+      }
+      if (nextServ == "home_timeline_service")
+      {
+         return 100;
+      }
+      if (nextServ == "social_graph_service")
+      {
+         return 100;
+      }
+      if (nextServ == "user_timeline_service")
+      {
+         return 100;
+      }
+      if (nextServ == "post_storage_service")
+      {
+         return 100;
+      }
+      if (nextServ == "url_shorten_service")
+      {
+         return 100;
+      }
+      break;
+   }
+   return -1; // WE SHOULD NEVER GET TO THAT POINT
+}
+
+std::string reqTypeToStr(RequestType t)
+{
+   switch (t)
+   {
+   case RequestType::COMPOSE:
+      return "COMPOSE";
+      break;
+   case RequestType::COMPOSE_0:
+      return "COMPOSE_0";
+      break;
+   case RequestType::COMPOSE_1:
+      return "COMPOSE_1";
+      break;
+   }
+   return "WTF";
+}
+
+void run(std::map<std::string, std::vector<std::string>> configServices, double freq)
+{
+   XBT_INFO("Starting run()");
+
+   ElasticPolicyCPUKubLeast *elastic = new ElasticPolicyCPUKubLeast(15, 20, 80);
+
+   // create ETM for service nginx_web_server
+   std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();
+   v_serv_nginx_web_server.push_back("nginx_web_server");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_nginx_web_server = std::make_shared<sg_microserv::ElasticTaskManager>("nginx_web_server", v_serv_nginx_web_server, true);
+   serv_nginx_web_server->setBootDuration(0);
+   // serv_nginx_web_server->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_nginx_web_server->setParallelTasksPerInst(std::stoi(configServices.find("nginx_web_server")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_nginx_web_server->setExecRatio(std::stod(configServices.find("nginx_web_server")->second.at(1)));
+   serv_nginx_web_server->setOutputFunction(return_nginx_web_server);
+   serv_nginx_web_server->setExecAmountFunc(pr_nginx_web_server);
+   serv_nginx_web_server->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
+   serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_nginx_web_server", simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)), [serv_nginx_web_server]
+                               { serv_nginx_web_server->run(); });
+
+   elastic->addElasticTaskManager(serv_nginx_web_server.get());
+   
+   // create ETM for service compose_post_service
+   std::vector<std::string> v_serv_compose_post_service = std::vector<std::string>();
+   v_serv_compose_post_service.push_back("compose_post_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_compose_post_service = std::make_shared<sg_microserv::ElasticTaskManager>("compose_post_service", v_serv_compose_post_service, true);
+   serv_compose_post_service->setBootDuration(0);
+   // serv_compose_post_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_compose_post_service->setParallelTasksPerInst(std::stoi(configServices.find("compose_post_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_compose_post_service->setExecRatio(std::stod(configServices.find("compose_post_service")->second.at(1)));
+   serv_compose_post_service->setOutputFunction(return_compose_post_service);
+   serv_compose_post_service->setExecAmountFunc(pr_compose_post_service);
+   serv_compose_post_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
+   serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_compose_post_service", simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)), [serv_compose_post_service]
+                               { serv_compose_post_service->run(); });
+   elastic->addElasticTaskManager(serv_compose_post_service.get());
+
+   // create ETM for service unique_id_service
+   std::vector<std::string> v_serv_unique_id_service = std::vector<std::string>();
+   v_serv_unique_id_service.push_back("unique_id_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_unique_id_service = std::make_shared<sg_microserv::ElasticTaskManager>("unique_id_service", v_serv_unique_id_service, true);
+   serv_unique_id_service->setBootDuration(0);
+   // serv_unique_id_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_unique_id_service->setParallelTasksPerInst(std::stoi(configServices.find("unique_id_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_unique_id_service->setExecRatio(std::stod(configServices.find("unique_id_service")->second.at(1)));
+   serv_unique_id_service->setOutputFunction(return_unique_id_service);
+   serv_unique_id_service->setExecAmountFunc(pr_unique_id_service);
+   serv_unique_id_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
+   serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_unique_id_service", simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)), [serv_unique_id_service]
+                               { serv_unique_id_service->run(); });
+   elastic->addElasticTaskManager(serv_unique_id_service.get());
+
+   // create ETM for service media_service
+   std::vector<std::string> v_serv_media_service = std::vector<std::string>();
+   v_serv_media_service.push_back("media_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_media_service = std::make_shared<sg_microserv::ElasticTaskManager>("media_service", v_serv_media_service, true);
+   serv_media_service->setBootDuration(0);
+   // serv_media_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_media_service->setParallelTasksPerInst(std::stoi(configServices.find("media_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_media_service->setExecRatio(std::stod(configServices.find("media_service")->second.at(1)));
+   serv_media_service->setOutputFunction(return_media_service);
+   serv_media_service->setExecAmountFunc(pr_media_service);
+   serv_media_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
+   serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_media_service", simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)), [serv_media_service]
+                               { serv_media_service->run(); });
+   elastic->addElasticTaskManager(serv_media_service.get());
+
+   // create ETM for service user_service
+   std::vector<std::string> v_serv_user_service = std::vector<std::string>();
+   v_serv_user_service.push_back("user_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_service", v_serv_user_service, true);
+   serv_user_service->setBootDuration(0);
+   // serv_user_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_user_service->setParallelTasksPerInst(std::stoi(configServices.find("user_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_user_service->setExecRatio(std::stod(configServices.find("user_service")->second.at(1)));
+   serv_user_service->setOutputFunction(return_user_service);
+   serv_user_service->setExecAmountFunc(pr_user_service);
+   serv_user_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
+   serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_user_service", simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)), [serv_user_service]
+                               { serv_user_service->run(); });
+   elastic->addElasticTaskManager(serv_user_service.get());
+
+   // create ETM for service text_service
+   std::vector<std::string> v_serv_text_service = std::vector<std::string>();
+   v_serv_text_service.push_back("text_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_text_service = std::make_shared<sg_microserv::ElasticTaskManager>("text_service", v_serv_text_service, true);
+   serv_text_service->setBootDuration(0);
+   // serv_text_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_text_service->setParallelTasksPerInst(std::stoi(configServices.find("text_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_text_service->setExecRatio(std::stod(configServices.find("text_service")->second.at(1)));
+   serv_text_service->setOutputFunction(return_text_service);
+   serv_text_service->setExecAmountFunc(pr_text_service);
+   serv_text_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
+   serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_text_service", simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)), [serv_text_service]
+                               { serv_text_service->run(); });
+   elastic->addElasticTaskManager(serv_text_service.get());
+
+   // create ETM for service user_mention_service
+   std::vector<std::string> v_serv_user_mention_service = std::vector<std::string>();
+   v_serv_user_mention_service.push_back("user_mention_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_mention_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_mention_service", v_serv_user_mention_service, true);
+   serv_user_mention_service->setBootDuration(0);
+   // serv_user_mention_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_user_mention_service->setParallelTasksPerInst(std::stoi(configServices.find("user_mention_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_user_mention_service->setExecRatio(std::stod(configServices.find("user_mention_service")->second.at(1)));
+   serv_user_mention_service->setOutputFunction(return_user_mention_service);
+   serv_user_mention_service->setExecAmountFunc(pr_user_mention_service);
+   serv_user_mention_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
+   serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_user_mention_service", simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)), [serv_user_mention_service]
+                               { serv_user_mention_service->run(); });
+   elastic->addElasticTaskManager(serv_user_mention_service.get());
+
+   // create ETM for service home_timeline_service
+   std::vector<std::string> v_serv_home_timeline_service = std::vector<std::string>();
+   v_serv_home_timeline_service.push_back("home_timeline_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_home_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("home_timeline_service", v_serv_home_timeline_service, true);
+   serv_home_timeline_service->setBootDuration(0);
+   // serv_home_timeline_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_home_timeline_service->setParallelTasksPerInst(std::stoi(configServices.find("home_timeline_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_home_timeline_service->setExecRatio(std::stod(configServices.find("home_timeline_service")->second.at(1)));
+   serv_home_timeline_service->setOutputFunction(return_home_timeline_service);
+   serv_home_timeline_service->setExecAmountFunc(pr_home_timeline_service);
+   serv_home_timeline_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
+   serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_home_timeline_service", simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)), [serv_home_timeline_service]
+                               { serv_home_timeline_service->run(); });
+   elastic->addElasticTaskManager(serv_home_timeline_service.get());
+
+   // create ETM for service social_graph_service
+   std::vector<std::string> v_serv_social_graph_service = std::vector<std::string>();
+   v_serv_social_graph_service.push_back("social_graph_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_social_graph_service = std::make_shared<sg_microserv::ElasticTaskManager>("social_graph_service", v_serv_social_graph_service, true);
+   serv_social_graph_service->setBootDuration(0);
+   // serv_social_graph_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_social_graph_service->setParallelTasksPerInst(std::stoi(configServices.find("social_graph_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_social_graph_service->setExecRatio(std::stod(configServices.find("social_graph_service")->second.at(1)));
+   serv_social_graph_service->setOutputFunction(return_social_graph_service);
+   serv_social_graph_service->setExecAmountFunc(pr_social_graph_service);
+   serv_social_graph_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
+   serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_social_graph_service", simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)), [serv_social_graph_service]
+                               { serv_social_graph_service->run(); });
+   elastic->addElasticTaskManager(serv_social_graph_service.get());
+
+   // create ETM for service user_timeline_service
+   std::vector<std::string> v_serv_user_timeline_service = std::vector<std::string>();
+   v_serv_user_timeline_service.push_back("user_timeline_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_timeline_service", v_serv_user_timeline_service, true);
+   serv_user_timeline_service->setBootDuration(0);
+   // serv_user_timeline_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_user_timeline_service->setParallelTasksPerInst(std::stoi(configServices.find("user_timeline_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_user_timeline_service->setExecRatio(std::stod(configServices.find("user_timeline_service")->second.at(1)));
+   serv_user_timeline_service->setOutputFunction(return_user_timeline_service);
+   serv_user_timeline_service->setExecAmountFunc(pr_user_timeline_service);
+   serv_user_timeline_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
+   serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_user_timeline_service", simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)), [serv_user_timeline_service]
+                               { serv_user_timeline_service->run(); });
+   elastic->addElasticTaskManager(serv_user_timeline_service.get());
+
+   // create ETM for service post_storage_service
+   std::vector<std::string> v_serv_post_storage_service = std::vector<std::string>();
+   v_serv_post_storage_service.push_back("post_storage_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_post_storage_service = std::make_shared<sg_microserv::ElasticTaskManager>("post_storage_service", v_serv_post_storage_service, true);
+   serv_post_storage_service->setBootDuration(0);
+   // serv_post_storage_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_post_storage_service->setParallelTasksPerInst(std::stoi(configServices.find("post_storage_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_post_storage_service->setExecRatio(std::stod(configServices.find("post_storage_service")->second.at(1)));
+   serv_post_storage_service->setOutputFunction(return_post_storage_service);
+   serv_post_storage_service->setExecAmountFunc(pr_post_storage_service);
+   serv_post_storage_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
+   serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_post_storage_service", simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)), [serv_post_storage_service]
+                               { serv_post_storage_service->run(); });
+   elastic->addElasticTaskManager(serv_post_storage_service.get());
+
+   // create ETM for service url_shorten_service
+   std::vector<std::string> v_serv_url_shorten_service = std::vector<std::string>();
+   v_serv_url_shorten_service.push_back("url_shorten_service");
+   std::shared_ptr<sg_microserv::ElasticTaskManager> serv_url_shorten_service = std::make_shared<sg_microserv::ElasticTaskManager>("url_shorten_service", v_serv_url_shorten_service, true);
+   serv_url_shorten_service->setBootDuration(0);
+   // serv_url_shorten_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+   // modify this value in the configuration file (parDeg)
+   serv_url_shorten_service->setParallelTasksPerInst(std::stoi(configServices.find("url_shorten_service")->second.at(2)));
+   // modify this value in the  configuration file (execRatio)
+   serv_url_shorten_service->setExecRatio(std::stod(configServices.find("url_shorten_service")->second.at(1)));
+   serv_url_shorten_service->setOutputFunction(return_url_shorten_service);
+   serv_url_shorten_service->setExecAmountFunc(pr_url_shorten_service);
+   serv_url_shorten_service->setReqNames(reqTypeToStr);
+   // set the host location in the config file (location)
+   serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
+   serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
+   simgrid::s4u::Engine::get_instance()->add_actor("etm_url_shorten_service", simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)), [serv_url_shorten_service]
+                               { serv_url_shorten_service->run(); });
+   elastic->addElasticTaskManager(serv_url_shorten_service.get());
+
+   simgrid::s4u::ActorPtr elasticActor = simgrid::s4u::Engine::get_instance()->add_actor("Kubernetes", simgrid::s4u::Host::by_name("clemth.irisa.fr"), [&]
+   { elastic->run(); });
+                            
+
+   /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
+   DataSourceFixedInterval *dsf = new DataSourceFixedInterval("nginx_web_server", RequestType::COMPOSE, 1 / freq, 100);
+   simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("clemth.irisa.fr"), [&]
+                                                               { dsf->run(); });
+
+   // kill policies and ETMs
+   simgrid::s4u::this_actor::sleep_for(35); /*set it according to your needs*/
+   dataS->kill();
+   simgrid::s4u::this_actor::sleep_for(2); /*set it according to your needs*/
+   XBT_INFO("Done. Killing policies and etms");
+   try
+   {
+      // dataS->kill();
+      serv_nginx_web_server->kill();
+      serv_compose_post_service->kill();
+      serv_unique_id_service->kill();
+      serv_media_service->kill();
+      serv_user_service->kill();
+      serv_text_service->kill();
+      serv_user_mention_service->kill();
+      serv_home_timeline_service->kill();
+      serv_social_graph_service->kill();
+      serv_user_timeline_service->kill();
+      serv_post_storage_service->kill();
+      serv_url_shorten_service->kill();
+      elasticActor->kill();
+   }
+   catch (simgrid::NetworkFailureException e)
+   {
+      std::cout << "netowrkexecption" << std::endl;
+   }
+   calls_csv->flush_buffer();
+   delete calls_csv;
+   calls_csv = nullptr;
+}
+int main(int argc, char *argv[])
+{
+   if (argc <= 2)
+   {
+      std::cout << "Wrong execution line" << std::endl;
+      std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv>" << std::endl;
+      exit(1);
+   }
+
+   calls_csv = new WriteBuffer("calls.csv");
+   calls_csv->append_text("received,ended,response_time\n");
+
+   // read the config from the file provided by the user
+   std::ifstream input(argv[2]);
+   std::map<std::string, std::vector<std::string>> servConfig;
+   std::string v;
+   // pass header
+   input >> v >> v >> v >> v;
+   for (std::string servName, servLocation, servExecRatio, servParDeg; input >> servName >> servLocation >> servExecRatio >> servParDeg;)
+   {
+      servConfig[servName] = {servLocation, servExecRatio, servParDeg};
+   }
+
+   simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
+   e->load_platform(argv[1]);
+   simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
+                               { run(servConfig, std::stod(argv[3])); });
+   e->run();
+   return 0;
+}

--- a/examples/DSB.cpp
+++ b/examples/DSB.cpp
@@ -1059,10 +1059,10 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
 }
 int main(int argc, char *argv[])
 {
-   if (argc <= 2)
+   if (argc <= 3)
    {
       std::cout << "Wrong execution line" << std::endl;
-      std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv>" << std::endl;
+      std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv> <calls frequency>" << std::endl;
       exit(1);
    }
 

--- a/examples/DSB.cpp
+++ b/examples/DSB.cpp
@@ -775,7 +775,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
 {
    XBT_INFO("Starting run()");
 
-   ElasticPolicyCPUKubLeast *elastic = new ElasticPolicyCPUKubLeast(15, 20, 80);
+   ElasticPolicyCPUKubLeast *elastic = new ElasticPolicyCPUKubLeast(15, 80, 20);
 
    // create ETM for service nginx_web_server
    std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();

--- a/examples/DSB.cpp
+++ b/examples/DSB.cpp
@@ -776,7 +776,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
 {
    XBT_INFO("Starting run()");
 
-   ElasticPolicyCPUKubLeast *elastic = new ElasticPolicyCPUKubLeast(15, 80, 20);
+   ElasticPolicyCPUKubLeast *elastic = new ElasticPolicyCPUKubLeast(15, 20, 80);
 
    // create ETM for service nginx_web_server
    std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();

--- a/examples/DSB.cpp
+++ b/examples/DSB.cpp
@@ -10,6 +10,7 @@
 #include "DataSource.hpp"
 #include <memory>
 #include "WriteBuffer.hpp"
+#include "simgrid/plugins/energy.h"
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(run_log, "logs of the experiment");
 
@@ -1081,6 +1082,9 @@ int main(int argc, char *argv[])
    }
 
    simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
+
+   sg_host_energy_plugin_init();
+
    e->load_platform(argv[1]);
    simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
                                { run(servConfig, std::stod(argv[3])); });

--- a/examples/DataSourceTest.cpp
+++ b/examples/DataSourceTest.cpp
@@ -26,8 +26,8 @@ int main(int argc, char* argv[]) {
 	e->load_platform(argv[1]);
 
   DataSourceFixedInterval* ds = new DataSourceFixedInterval("testOut", 10, 10000);
-	simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
-  simgrid::s4u::Actor::create("rec", simgrid::s4u::Host::by_name("cb1-1"), [&]{receiver();});
+  e->add_actor("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
+  e->add_actor("rec", simgrid::s4u::Host::by_name("cb1-1"), [&]{receiver();});
 	e->run();
 	return 0;
 }

--- a/examples/bench1.cpp
+++ b/examples/bench1.cpp
@@ -66,7 +66,7 @@ void run(int servFlops, std::string tsFile, int parDeg) {
 
   etmservice1->setOutputFunction(returnservice1);
   etmservice1->setParallelTasksPerInst(parDeg);
-  simgrid::s4u::Actor::create("etmservice1_a", simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice1_a", simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
   /* 3 instances (not using an elastic policy here, see other examples) */
   etmservice1->addHost(simgrid::s4u::Host::by_name("cb1-2"));
   etmservice1->setExecAmount(servFlops);
@@ -79,7 +79,7 @@ void run(int servFlops, std::string tsFile, int parDeg) {
   std::shared_ptr<sg_microserv::ElasticTaskManager> etmservice2 = std::make_shared<sg_microserv::ElasticTaskManager>("etmservice2",vservice2);
   etmservice2->setParallelTasksPerInst(parDeg);
   etmservice2->setOutputFunction(returnservice2);
-  simgrid::s4u::Actor::create("etmservice2_a", simgrid::s4u::Host::by_name("cb1-100"), [etmservice2] { etmservice2->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice2_a", simgrid::s4u::Host::by_name("cb1-100"), [etmservice2] { etmservice2->run(); });
   /* 2 instances */
   etmservice2->addHost(simgrid::s4u::Host::by_name("cb1-101"));
   etmservice2->setExecAmount(1);
@@ -92,7 +92,7 @@ void run(int servFlops, std::string tsFile, int parDeg) {
   //DataSourceFixedInterval* ds = new DataSourceFixedInterval("service1", .5, 10000);
   //DataSourceTSFile* ds = new DataSourceTSFile("service1", "default5TimeStamps.csv", 1000);
   DataSourceTSFile* ds = new DataSourceTSFile("service1", tsFile, 1000);
-	simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
+	simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
 
   // kill policies and ETMs
   simgrid::s4u::this_actor::sleep_for(350);
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
 	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
 	e->load_platform(argv[1]);
 
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run(std::stoi(argv[2]), argv[3], std::stoi(argv[4]));});
+	simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run(std::stoi(argv[2]), argv[3], std::stoi(argv[4]));});
 	e->run();
 	return 0;
 }

--- a/examples/bench2.cpp
+++ b/examples/bench2.cpp
@@ -78,7 +78,7 @@ void run(int serv1Flops, int serv2Flops, std::string tsFile, int parDeg) {
 
   etmservice1->setOutputFunction(returnservice1);
   etmservice1->setParallelTasksPerInst(parDeg);
-  simgrid::s4u::Actor::create("etmservice1_a", simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice1_a", simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
   /* 3 instances (not using an elastic policy here, see other examples) */
   etmservice1->addHost(simgrid::s4u::Host::by_name("cb1-2"));
   etmservice1->setExecAmount(serv1Flops);
@@ -91,7 +91,7 @@ void run(int serv1Flops, int serv2Flops, std::string tsFile, int parDeg) {
   std::shared_ptr<sg_microserv::ElasticTaskManager> etmservice2 = std::make_shared<sg_microserv::ElasticTaskManager>("etmservice2",vservice2);
   etmservice2->setParallelTasksPerInst(parDeg);
   etmservice2->setOutputFunction(returnservice2);
-  simgrid::s4u::Actor::create("etmservice2_a", simgrid::s4u::Host::by_name("cb1-100"), [etmservice2] { etmservice2->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice2_a", simgrid::s4u::Host::by_name("cb1-100"), [etmservice2] { etmservice2->run(); });
   /* 2 instances */
   etmservice2->addHost(simgrid::s4u::Host::by_name("cb1-101"));
   etmservice2->setExecAmount(serv2Flops);
@@ -105,7 +105,7 @@ void run(int serv1Flops, int serv2Flops, std::string tsFile, int parDeg) {
 
   etmservice3->setOutputFunction(returnservice3);
   etmservice3->setParallelTasksPerInst(parDeg);
-  simgrid::s4u::Actor::create("etmservice1_a", simgrid::s4u::Host::by_name("cb1-3"), [etmservice3] { etmservice3->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice1_a", simgrid::s4u::Host::by_name("cb1-3"), [etmservice3] { etmservice3->run(); });
   /* 3 instances (not using an elastic policy here, see other examples) */
   etmservice3->addHost(simgrid::s4u::Host::by_name("cb1-4"));
   etmservice3->setExecAmount(0);
@@ -117,7 +117,7 @@ void run(int serv1Flops, int serv2Flops, std::string tsFile, int parDeg) {
   //DataSourceFixedInterval* ds = new DataSourceFixedInterval("service1", .5, 10000);
   //DataSourceTSFile* ds = new DataSourceTSFile("service1", "default5TimeStamps.csv", 1000);
   DataSourceTSFile* ds = new DataSourceTSFile("service1", tsFile, 1000);
-	simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
+	simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
 
   // kill policies and ETMs
   simgrid::s4u::this_actor::sleep_for(350);
@@ -138,7 +138,7 @@ int main(int argc, char* argv[]) {
 	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
 	e->load_platform(argv[1]);
 
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run(std::stoi(argv[2]), std::stoi(argv[3]), argv[4], std::stoi(argv[5]));});
+	simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run(std::stoi(argv[2]), std::stoi(argv[3]), argv[4], std::stoi(argv[5]));});
 	e->run();
 	return 0;
 }

--- a/examples/cpuRatioExample.cpp
+++ b/examples/cpuRatioExample.cpp
@@ -21,6 +21,7 @@ using namespace sg_microserv;
 void returnservice1(TaskDescription* td) {
   XBT_INFO("Execution: cost=%lf, Started=%lf, ended=%lf ratio=%lf",
     EXEC_COST, td->startExec, td->endExec, EXEC_RATIO);
+#ifdef USE_JAEGERTRACING    
   for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it) {
     if ((*it)->get() != NULL) {
       auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(
@@ -31,6 +32,7 @@ void returnservice1(TaskDescription* td) {
       (*it) == NULL;
     }
   }
+#endif /*USE_JAEGERTRACING*/
         delete td;
 }
 
@@ -51,14 +53,14 @@ void run() {
   etmservice1->setExecRatio(EXEC_RATIO);
   etmservice1->setBootDuration(0);
   etmservice1->addHost(simgrid::s4u::Host::by_name("cb1-1"));
-  simgrid::s4u::Actor::create("etmservice1_a",
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice1_a",
     simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
 
   /*
   * Create data source
   */
   DataSourceFixedInterval* dsf = new DataSourceFixedInterval("service1", RequestType::DEFAULT, 1, 100);
-  simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create(
+  simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor(
     "snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{dsf->run();});
 
   // kill policies and ETMs
@@ -72,7 +74,7 @@ void run() {
 int main(int argc, char* argv[]) {
   simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
   e->load_platform(argv[1]);
-  simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-2"), [&]{run();});
+  simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name("cb1-2"), [&]{run();});
   e->run();
   return 0;
 }

--- a/examples/generated_2inst.cpp
+++ b/examples/generated_2inst.cpp
@@ -16,796 +16,1025 @@ using namespace sg_microserv;
 
 int outSizes(RequestType, std::string);
 /* RETURN FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
-    void return_nginx_web_server(TaskDescription* td) {
+void return_nginx_web_server(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service nginx_web_server");
-      switch (td->requestType) {
-case RequestType::COMPOSE:
-      if(td->nbHops == 1) {
-        XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+      switch (td->requestType)
+      {
+      case RequestType::COMPOSE:
+            if (td->nbHops == 1)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
 
-
-break;
+                  break;
+            }
+      }
 }
-	}
-}
-    void return_compose_post_service(TaskDescription* td) {
+void return_compose_post_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service compose_post_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 2){
-        XBT_DEBUG("Output Function for COMPOSE, put to unique_id_service");
-        s4u_Mailbox* m_unique_id_service = s4u_Mailbox::by_name("unique_id_service");
-        m_unique_id_service->put(td, outSizes(td->requestType, "unique_id_service"));
+      case RequestType::COMPOSE:
+            if (td->nbHops == 2)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to unique_id_service");
+                  s4u_Mailbox *m_unique_id_service = s4u_Mailbox::by_name("unique_id_service");
+                  m_unique_id_service->put(td, outSizes(td->requestType, "unique_id_service"));
 
+                  break;
+            }
 
-break;
+            if (td->nbHops == 4)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to media_service");
+                  s4u_Mailbox *m_media_service = s4u_Mailbox::by_name("media_service");
+                  m_media_service->put(td, outSizes(td->requestType, "media_service"));
+
+                  break;
+            }
+
+            if (td->nbHops == 6)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to user_service");
+                  s4u_Mailbox *m_user_service = s4u_Mailbox::by_name("user_service");
+                  m_user_service->put(td, outSizes(td->requestType, "user_service"));
+
+                  break;
+            }
+
+            if (td->nbHops == 8)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to text_service");
+                  s4u_Mailbox *m_text_service = s4u_Mailbox::by_name("text_service");
+                  m_text_service->put(td, outSizes(td->requestType, "text_service"));
+
+                  break;
+            }
+
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 12)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to home_timeline_service");
+                  s4u_Mailbox *m_home_timeline_service = s4u_Mailbox::by_name("home_timeline_service");
+                  m_home_timeline_service->put(td, outSizes(td->requestType, "home_timeline_service"));
+
+                  break;
+            }
+
+            if (td->nbHops == 16)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to user_timeline_service");
+                  s4u_Mailbox *m_user_timeline_service = s4u_Mailbox::by_name("user_timeline_service");
+                  m_user_timeline_service->put(td, outSizes(td->requestType, "user_timeline_service"));
+
+                  break;
+            }
+
+            if (td->nbHops == 18)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to post_storage_service");
+                  s4u_Mailbox *m_post_storage_service = s4u_Mailbox::by_name("post_storage_service");
+                  m_post_storage_service->put(td, outSizes(td->requestType, "post_storage_service"));
+
+                  break;
+            }
+
+            break;
+      }
 }
-
-      if(td->nbHops == 4){
-        XBT_DEBUG("Output Function for COMPOSE, put to media_service");
-        s4u_Mailbox* m_media_service = s4u_Mailbox::by_name("media_service");
-        m_media_service->put(td, outSizes(td->requestType, "media_service"));
-
-
-break;
-}
-
-      if(td->nbHops == 6){
-        XBT_DEBUG("Output Function for COMPOSE, put to user_service");
-        s4u_Mailbox* m_user_service = s4u_Mailbox::by_name("user_service");
-        m_user_service->put(td, outSizes(td->requestType, "user_service"));
-
-
-break;
-}
-
-      if(td->nbHops == 8){
-        XBT_DEBUG("Output Function for COMPOSE, put to text_service");
-        s4u_Mailbox* m_text_service = s4u_Mailbox::by_name("text_service");
-        m_text_service->put(td, outSizes(td->requestType, "text_service"));
-
-
-break;
-}
-
-
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 12){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to home_timeline_service");
-        s4u_Mailbox* m_home_timeline_service = s4u_Mailbox::by_name("home_timeline_service");
-        m_home_timeline_service->put(td, outSizes(td->requestType, "home_timeline_service"));
-
-
-break;
-}
-
-      if(td->nbHops == 16){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to user_timeline_service");
-        s4u_Mailbox* m_user_timeline_service = s4u_Mailbox::by_name("user_timeline_service");
-        m_user_timeline_service->put(td, outSizes(td->requestType, "user_timeline_service"));
-
-
-break;
-}
-
-      if(td->nbHops == 18){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to post_storage_service");
-        s4u_Mailbox* m_post_storage_service = s4u_Mailbox::by_name("post_storage_service");
-        m_post_storage_service->put(td, outSizes(td->requestType, "post_storage_service"));
-
-
-break;
-}
-
-break;
-	}
-}
-    void return_unique_id_service(TaskDescription* td) {
+void return_unique_id_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service unique_id_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 3){
-        XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+      case RequestType::COMPOSE:
+            if (td->nbHops == 3)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
 
-
-break;
+                  break;
+            }
+      }
 }
-	}
-}
-    void return_media_service(TaskDescription* td) {
+void return_media_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service media_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 5){
-        XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+      case RequestType::COMPOSE:
+            if (td->nbHops == 5)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
 
-
-break;
+                  break;
+            }
+      }
 }
-	}
-}
-    void return_user_service(TaskDescription* td) {
+void return_user_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service user_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 7){
-        XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+      case RequestType::COMPOSE:
+            if (td->nbHops == 7)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
 
-
-break;
+                  break;
+            }
+      }
 }
-	}
-}
-    void return_text_service(TaskDescription* td) {
+void return_text_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service text_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 9){
-        XBT_DEBUG("Output Function for text_service (PARALLEL CHILDS)");
-        std::vector<simgrid::s4u::CommPtr> comV;
-        simgrid::s4u::CommPtr com;
+      case RequestType::COMPOSE:
+            if (td->nbHops == 9)
+            {
+                  XBT_DEBUG("Output Function for text_service (PARALLEL CHILDS)");
+                  ActivitySet commV;
+                  simgrid::s4u::CommPtr com;
 
-          XBT_DEBUG("Put to text_service");
-          s4u_Mailbox* m_text_service = s4u_Mailbox::by_name("text_service");
-          TaskDescription* td_0 = new TaskDescription(*td);
-          td_0->requestType = RequestType::COMPOSE_0;
-          com = m_text_service->put_async(td_0, outSizes(td_0->requestType, "text_service"));
-          comV.push_back(com);
+                  XBT_DEBUG("Put to text_service");
+                  s4u_Mailbox *m_text_service = s4u_Mailbox::by_name("text_service");
+                  TaskDescription *td_0 = new TaskDescription(*td);
+                  td_0->requestType = RequestType::COMPOSE_0;
+                  com = m_text_service->put_async(td_0, outSizes(td_0->requestType, "text_service"));
+                  commV.push(com);
 
-          XBT_DEBUG("Put to text_service");
-          s4u_Mailbox* m_text_service_ = s4u_Mailbox::by_name("text_service");
-          TaskDescription* td_1 = new TaskDescription(*td);
-          td_1->requestType = RequestType::COMPOSE_1;
-          com = m_text_service_->put_async(td_1, outSizes(td_1->requestType, "text_service"));
-          comV.push_back(com);
+                  XBT_DEBUG("Put to text_service");
+                  s4u_Mailbox *m_text_service_ = s4u_Mailbox::by_name("text_service");
+                  TaskDescription *td_1 = new TaskDescription(*td);
+                  td_1->requestType = RequestType::COMPOSE_1;
+                  com = m_text_service_->put_async(td_1, outSizes(td_1->requestType, "text_service"));
+                  commV.push(com);
+                  commV.wait_all();
+                  break;
+            }
 
-simgrid::s4u::Comm::wait_all(&comV); // wait for communications to finish
-break;
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 10)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to user_mention_service");
+                  s4u_Mailbox *m_user_mention_service = s4u_Mailbox::by_name("user_mention_service");
+                  m_user_mention_service->put(td, outSizes(td->requestType, "user_mention_service"));
+
+                  break;
+            }
+
+            break;
+
+      case RequestType::COMPOSE_1:
+            if (td->nbHops == 10)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_1, put to url_shorten_service");
+                  s4u_Mailbox *m_url_shorten_service = s4u_Mailbox::by_name("url_shorten_service");
+                  m_url_shorten_service->put(td, outSizes(td->requestType, "url_shorten_service"));
+
+                  break;
+            }
+
+            break;
+      }
 }
-
-
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 10){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to user_mention_service");
-        s4u_Mailbox* m_user_mention_service = s4u_Mailbox::by_name("user_mention_service");
-        m_user_mention_service->put(td, outSizes(td->requestType, "user_mention_service"));
-
-
-break;
-}
-
-break;
-
-
-case RequestType::COMPOSE_1:
-      if(td->nbHops == 10){
-        XBT_DEBUG("Output Function for COMPOSE_1, put to url_shorten_service");
-        s4u_Mailbox* m_url_shorten_service = s4u_Mailbox::by_name("url_shorten_service");
-        m_url_shorten_service->put(td, outSizes(td->requestType, "url_shorten_service"));
-
-
-break;
-}
-
-break;
-	}
-}
-    void return_user_mention_service(TaskDescription* td) {
+void return_user_mention_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service user_mention_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 11){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 11)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
 
+                  break;
+            }
 
-break;
+            break;
+      }
 }
-
-break;
-	}
-}
-    void return_home_timeline_service(TaskDescription* td) {
+void return_home_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service home_timeline_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 13){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to social_graph_service");
-        s4u_Mailbox* m_social_graph_service = s4u_Mailbox::by_name("social_graph_service");
-        m_social_graph_service->put(td, outSizes(td->requestType, "social_graph_service"));
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 13)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to social_graph_service");
+                  s4u_Mailbox *m_social_graph_service = s4u_Mailbox::by_name("social_graph_service");
+                  m_social_graph_service->put(td, outSizes(td->requestType, "social_graph_service"));
 
+                  break;
+            }
 
-break;
+            if (td->nbHops == 15)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+
+                  break;
+            }
+
+            break;
+      }
 }
-
-      if(td->nbHops == 15){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
-
-
-break;
-}
-
-break;
-	}
-}
-    void return_social_graph_service(TaskDescription* td) {
+void return_social_graph_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service social_graph_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 14){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to home_timeline_service");
-        s4u_Mailbox* m_home_timeline_service = s4u_Mailbox::by_name("home_timeline_service");
-        m_home_timeline_service->put(td, outSizes(td->requestType, "home_timeline_service"));
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 14)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to home_timeline_service");
+                  s4u_Mailbox *m_home_timeline_service = s4u_Mailbox::by_name("home_timeline_service");
+                  m_home_timeline_service->put(td, outSizes(td->requestType, "home_timeline_service"));
 
+                  break;
+            }
 
-break;
+            break;
+      }
 }
-
-break;
-	}
-}
-    void return_user_timeline_service(TaskDescription* td) {
+void return_user_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service user_timeline_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 17){
-        XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
-        s4u_Mailbox* m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
-        m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 17)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_0, put to compose_post_service");
+                  s4u_Mailbox *m_compose_post_service = s4u_Mailbox::by_name("compose_post_service");
+                  m_compose_post_service->put(td, outSizes(td->requestType, "compose_post_service"));
 
+                  break;
+            }
 
-break;
+            break;
+      }
 }
-
-break;
-	}
-}
-    void return_post_storage_service(TaskDescription* td) {
+void return_post_storage_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service post_storage_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 19){
-            XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock()-td->firstArrivalDate);
-        XBT_DEBUG("Output Function for COMPOSE_0, Final service, DELETE");
-        for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if((*it)->get() != NULL){
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }
-        delete td;
+      case RequestType::COMPOSE_0:
+            #ifdef USE_JAEGERTRACING
+            if (td->nbHops == 19)
+            {
+                  XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock() - td->firstArrivalDate);
+                  XBT_DEBUG("Output Function for COMPOSE_0, Final service, DELETE");
+                  for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+                  {
+                        if ((*it)->get() != NULL)
+                        {
+                              auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+                              (*it)->get()->Log({{"end", t2.count()}});
+                              (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+                              (*it)->reset();
+                              (*it) == NULL;
+                        }
+                  }
+                  delete td;
+            }
+            #endif /*USE_JAEGERTRACING*/
+            break;
       }
-
-break;
-	}
 }
-    void return_url_shorten_service(TaskDescription* td) {
+void return_url_shorten_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service url_shorten_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_1:
-      if(td->nbHops == 11){
-        XBT_DEBUG("Output Function for COMPOSE_1, Final service, DELETE");
-        for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if((*it)->get() != NULL){
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }
-        delete td;
+      case RequestType::COMPOSE_1:
+            #ifdef USE_JAEGERTRACING
+            if (td->nbHops == 11)
+            {
+                  XBT_DEBUG("Output Function for COMPOSE_1, Final service, DELETE");
+                  for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+                  {
+                        if ((*it)->get() != NULL)
+                        {
+                              auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+                              (*it)->get()->Log({{"end", t2.count()}});
+                              (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+                              (*it)->reset();
+                              (*it) == NULL;
+                        }
+                  }
+                  delete td;
+            }
+            #endif /*USE_JAEGERTRACING*/
+            break;
       }
-
-break;
-	}
 }
 /* PR FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
-    double pr_nginx_web_server(TaskDescription* td) {
+double pr_nginx_web_server(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service nginx_web_server");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 1){XBT_DEBUG("Entered cost Function for COMPOSE"); return 500000;}
-      	}//it should never end up here
-return -1;
+      case RequestType::COMPOSE:
+            if (td->nbHops == 1)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 500000;
+            }
+      } // it should never end up here
+      return -1;
 }
-    double pr_compose_post_service(TaskDescription* td) {
+double pr_compose_post_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service compose_post_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 2){XBT_DEBUG("Entered cost Function for COMPOSE"); return 608000;}
+      case RequestType::COMPOSE:
+            if (td->nbHops == 2)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 608000;
+            }
 
-      if(td->nbHops == 4){XBT_DEBUG("Entered cost Function for COMPOSE"); return 118000;}
+            if (td->nbHops == 4)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 118000;
+            }
 
-      if(td->nbHops == 6){XBT_DEBUG("Entered cost Function for COMPOSE"); return 117000;}
+            if (td->nbHops == 6)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 117000;
+            }
 
-      if(td->nbHops == 8){XBT_DEBUG("Entered cost Function for COMPOSE"); return 134000;}
+            if (td->nbHops == 8)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 134000;
+            }
 
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 12)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 264000;
+            }
 
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 12){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 264000;}
+            if (td->nbHops == 16)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 173000;
+            }
 
-      if(td->nbHops == 16){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 173000;}
+            if (td->nbHops == 18)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 288000;
+            }
 
-      if(td->nbHops == 18){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 288000;}
-
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_unique_id_service(TaskDescription* td) {
+double pr_unique_id_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service unique_id_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 3){XBT_DEBUG("Entered cost Function for COMPOSE"); return 11000;}
-      	}//it should never end up here
-return -1;
+      case RequestType::COMPOSE:
+            if (td->nbHops == 3)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 11000;
+            }
+      } // it should never end up here
+      return -1;
 }
-    double pr_media_service(TaskDescription* td) {
+double pr_media_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service media_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 5){XBT_DEBUG("Entered cost Function for COMPOSE"); return 6000;}
-      	}//it should never end up here
-return -1;
+      case RequestType::COMPOSE:
+            if (td->nbHops == 5)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 6000;
+            }
+      } // it should never end up here
+      return -1;
 }
-    double pr_user_service(TaskDescription* td) {
+double pr_user_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service user_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 7){XBT_DEBUG("Entered cost Function for COMPOSE"); return 5000;}
-      	}//it should never end up here
-return -1;
+      case RequestType::COMPOSE:
+            if (td->nbHops == 7)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE");
+                  return 5000;
+            }
+      } // it should never end up here
+      return -1;
 }
-    double pr_text_service(TaskDescription* td) {
+double pr_text_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service text_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE:
-      if(td->nbHops == 9){XBT_DEBUG("Entered cost Function for text_service"); return 318000;
+      case RequestType::COMPOSE:
+            if (td->nbHops == 9)
+            {
+                  XBT_DEBUG("Entered cost Function for text_service");
+                  return 318000;
+            }
+            break;
+
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 10)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 159000;
+            }
+
+            break;
+
+      case RequestType::COMPOSE_1:
+            if (td->nbHops == 10)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_1");
+                  return 457000;
+            }
+
+            break;
+      } // it should never end up here
+      return -1;
 }
-break;
-
-
-
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 10){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 159000;}
-
-break;
-
-
-case RequestType::COMPOSE_1:
-      if(td->nbHops == 10){XBT_DEBUG("Entered cost Function for COMPOSE_1"); return 457000;}
-
-break;
-	}//it should never end up here
-return -1;
-}
-    double pr_user_mention_service(TaskDescription* td) {
+double pr_user_mention_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service user_mention_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 11){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 724000;}
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 11)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 724000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_home_timeline_service(TaskDescription* td) {
+double pr_home_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service home_timeline_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 13){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 168000;}
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 13)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 168000;
+            }
 
-      if(td->nbHops == 15){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 5000;}
+            if (td->nbHops == 15)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 5000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_social_graph_service(TaskDescription* td) {
+double pr_social_graph_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service social_graph_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 14){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 707000;}
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 14)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 707000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_user_timeline_service(TaskDescription* td) {
+double pr_user_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service user_timeline_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 17){XBT_DEBUG("Entered cost Function for COMPOSE_0"); return 834000;}
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 17)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0");
+                  return 834000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_post_storage_service(TaskDescription* td) {
+double pr_post_storage_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service post_storage_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_0:
-      if(td->nbHops == 19){XBT_DEBUG("Entered cost Function for COMPOSE_0 (FINAL NODE, NO CHILD!)"); return 508000;}
+      case RequestType::COMPOSE_0:
+            if (td->nbHops == 19)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_0 (FINAL NODE, NO CHILD!)");
+                  return 508000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_url_shorten_service(TaskDescription* td) {
+double pr_url_shorten_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service url_shorten_service");
       switch (td->requestType)
       {
-case RequestType::COMPOSE_1:
-      if(td->nbHops == 11){XBT_DEBUG("Entered cost Function for COMPOSE_1 (FINAL NODE, NO CHILD!)"); return 451000;}
+      case RequestType::COMPOSE_1:
+            if (td->nbHops == 11)
+            {
+                  XBT_DEBUG("Entered cost Function for COMPOSE_1 (FINAL NODE, NO CHILD!)");
+                  return 451000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-int outSizes(RequestType t, std::string nextServ){
-    switch (t)
-{	case RequestType::COMPOSE :
-	if(nextServ == "compose_post_service"){return 100;}
-	if(nextServ == "unique_id_service"){return 100;}
-	if(nextServ == "media_service"){return 100;}
-	if(nextServ == "user_service"){return 100;}
-	if(nextServ == "text_service"){return 100;}
-	if(nextServ == "user_mention_service"){return 100;}
-	if(nextServ == "home_timeline_service"){return 100;}
-	if(nextServ == "social_graph_service"){return 100;}
-	if(nextServ == "user_timeline_service"){return 100;}
-	if(nextServ == "post_storage_service"){return 100;}
-	if(nextServ == "url_shorten_service"){return 100;}
-	break;
-	case RequestType::COMPOSE_0 :
-	if(nextServ == "compose_post_service"){return 100;}
-	if(nextServ == "unique_id_service"){return 100;}
-	if(nextServ == "media_service"){return 100;}
-	if(nextServ == "user_service"){return 100;}
-	if(nextServ == "text_service"){return 100;}
-	if(nextServ == "user_mention_service"){return 100;}
-	if(nextServ == "home_timeline_service"){return 100;}
-	if(nextServ == "social_graph_service"){return 100;}
-	if(nextServ == "user_timeline_service"){return 100;}
-	if(nextServ == "post_storage_service"){return 100;}
-	if(nextServ == "url_shorten_service"){return 100;}
-	break;
-	case RequestType::COMPOSE_1 :
-	if(nextServ == "compose_post_service"){return 100;}
-	if(nextServ == "unique_id_service"){return 100;}
-	if(nextServ == "media_service"){return 100;}
-	if(nextServ == "user_service"){return 100;}
-	if(nextServ == "text_service"){return 100;}
-	if(nextServ == "user_mention_service"){return 100;}
-	if(nextServ == "home_timeline_service"){return 100;}
-	if(nextServ == "social_graph_service"){return 100;}
-	if(nextServ == "user_timeline_service"){return 100;}
-	if(nextServ == "post_storage_service"){return 100;}
-	if(nextServ == "url_shorten_service"){return 100;}
-	break;
-}return -1; // WE SHOULD NEVER GET TO THAT POINT
+int outSizes(RequestType t, std::string nextServ)
+{
+      switch (t)
+      {
+      case RequestType::COMPOSE:
+            if (nextServ == "compose_post_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "unique_id_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "media_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "text_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_mention_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "home_timeline_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "social_graph_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_timeline_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "post_storage_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "url_shorten_service")
+            {
+                  return 100;
+            }
+            break;
+      case RequestType::COMPOSE_0:
+            if (nextServ == "compose_post_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "unique_id_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "media_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "text_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_mention_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "home_timeline_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "social_graph_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_timeline_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "post_storage_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "url_shorten_service")
+            {
+                  return 100;
+            }
+            break;
+      case RequestType::COMPOSE_1:
+            if (nextServ == "compose_post_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "unique_id_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "media_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "text_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_mention_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "home_timeline_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "social_graph_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "user_timeline_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "post_storage_service")
+            {
+                  return 100;
+            }
+            if (nextServ == "url_shorten_service")
+            {
+                  return 100;
+            }
+            break;
+      }
+      return -1; // WE SHOULD NEVER GET TO THAT POINT
 }
 
-std::string reqTypeToStr(RequestType t){
-    switch (t)
-{	case RequestType::COMPOSE : return "COMPOSE";break;
-	case RequestType::COMPOSE_0 : return "COMPOSE_0";break;
-	case RequestType::COMPOSE_1 : return "COMPOSE_1";break;
-}return "WTF";
+std::string reqTypeToStr(RequestType t)
+{
+      switch (t)
+      {
+      case RequestType::COMPOSE:
+            return "COMPOSE";
+            break;
+      case RequestType::COMPOSE_0:
+            return "COMPOSE_0";
+            break;
+      case RequestType::COMPOSE_1:
+            return "COMPOSE_1";
+            break;
+      }
+      return "WTF";
 }
 
-  void run(std::map<std::string, std::vector<std::string>> configServices, double freq) {
-    XBT_INFO("Starting run()");
-    // create ETM for service nginx_web_server
-    std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();
-    v_serv_nginx_web_server.push_back("nginx_web_server");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_nginx_web_server = std::make_shared<sg_microserv::ElasticTaskManager>("nginx_web_server",v_serv_nginx_web_server);
-    serv_nginx_web_server->setBootDuration(0);
-    // serv_nginx_web_server->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_nginx_web_server->setParallelTasksPerInst(std::stoi(configServices.find("nginx_web_server")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_nginx_web_server->setExecRatio(std::stod(configServices.find("nginx_web_server")->second.at(1)));
-    serv_nginx_web_server->setOutputFunction(return_nginx_web_server);
-    serv_nginx_web_server->setExecAmountFunc(pr_nginx_web_server);
-    serv_nginx_web_server->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
-    serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)), [serv_nginx_web_server] { serv_nginx_web_server->run(); });
+void run(std::map<std::string, std::vector<std::string>> configServices, double freq)
+{
+      XBT_INFO("Starting run()");
+      // create ETM for service nginx_web_server
+      std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();
+      v_serv_nginx_web_server.push_back("nginx_web_server");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_nginx_web_server = std::make_shared<sg_microserv::ElasticTaskManager>("nginx_web_server", v_serv_nginx_web_server);
+      serv_nginx_web_server->setBootDuration(0);
+      // serv_nginx_web_server->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_nginx_web_server->setParallelTasksPerInst(std::stoi(configServices.find("nginx_web_server")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_nginx_web_server->setExecRatio(std::stod(configServices.find("nginx_web_server")->second.at(1)));
+      serv_nginx_web_server->setOutputFunction(return_nginx_web_server);
+      serv_nginx_web_server->setExecAmountFunc(pr_nginx_web_server);
+      serv_nginx_web_server->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
+      serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)), [serv_nginx_web_server]
+                                  { serv_nginx_web_server->run(); });
 
+      // create ETM for service compose_post_service
+      std::vector<std::string> v_serv_compose_post_service = std::vector<std::string>();
+      v_serv_compose_post_service.push_back("compose_post_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_compose_post_service = std::make_shared<sg_microserv::ElasticTaskManager>("compose_post_service", v_serv_compose_post_service);
+      serv_compose_post_service->setBootDuration(0);
+      // serv_compose_post_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_compose_post_service->setParallelTasksPerInst(std::stoi(configServices.find("compose_post_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_compose_post_service->setExecRatio(std::stod(configServices.find("compose_post_service")->second.at(1)));
+      serv_compose_post_service->setOutputFunction(return_compose_post_service);
+      serv_compose_post_service->setExecAmountFunc(pr_compose_post_service);
+      serv_compose_post_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
+      serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_compose_post_service", simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)), [serv_compose_post_service]
+                                  { serv_compose_post_service->run(); });
 
-    // create ETM for service compose_post_service
-    std::vector<std::string> v_serv_compose_post_service = std::vector<std::string>();
-    v_serv_compose_post_service.push_back("compose_post_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_compose_post_service = std::make_shared<sg_microserv::ElasticTaskManager>("compose_post_service",v_serv_compose_post_service);
-    serv_compose_post_service->setBootDuration(0);
-    // serv_compose_post_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_compose_post_service->setParallelTasksPerInst(std::stoi(configServices.find("compose_post_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_compose_post_service->setExecRatio(std::stod(configServices.find("compose_post_service")->second.at(1)));
-    serv_compose_post_service->setOutputFunction(return_compose_post_service);
-    serv_compose_post_service->setExecAmountFunc(pr_compose_post_service);
-    serv_compose_post_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
-    serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_compose_post_service", simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)), [serv_compose_post_service] { serv_compose_post_service->run(); });
+      // create ETM for service unique_id_service
+      std::vector<std::string> v_serv_unique_id_service = std::vector<std::string>();
+      v_serv_unique_id_service.push_back("unique_id_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_unique_id_service = std::make_shared<sg_microserv::ElasticTaskManager>("unique_id_service", v_serv_unique_id_service);
+      serv_unique_id_service->setBootDuration(0);
+      // serv_unique_id_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_unique_id_service->setParallelTasksPerInst(std::stoi(configServices.find("unique_id_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_unique_id_service->setExecRatio(std::stod(configServices.find("unique_id_service")->second.at(1)));
+      serv_unique_id_service->setOutputFunction(return_unique_id_service);
+      serv_unique_id_service->setExecAmountFunc(pr_unique_id_service);
+      serv_unique_id_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
+      serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_unique_id_service", simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)), [serv_unique_id_service]
+                                  { serv_unique_id_service->run(); });
 
+      // create ETM for service media_service
+      std::vector<std::string> v_serv_media_service = std::vector<std::string>();
+      v_serv_media_service.push_back("media_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_media_service = std::make_shared<sg_microserv::ElasticTaskManager>("media_service", v_serv_media_service);
+      serv_media_service->setBootDuration(0);
+      // serv_media_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_media_service->setParallelTasksPerInst(std::stoi(configServices.find("media_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_media_service->setExecRatio(std::stod(configServices.find("media_service")->second.at(1)));
+      serv_media_service->setOutputFunction(return_media_service);
+      serv_media_service->setExecAmountFunc(pr_media_service);
+      serv_media_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
+      serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_media_service", simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)), [serv_media_service]
+                                  { serv_media_service->run(); });
 
-    // create ETM for service unique_id_service
-    std::vector<std::string> v_serv_unique_id_service = std::vector<std::string>();
-    v_serv_unique_id_service.push_back("unique_id_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_unique_id_service = std::make_shared<sg_microserv::ElasticTaskManager>("unique_id_service",v_serv_unique_id_service);
-    serv_unique_id_service->setBootDuration(0);
-    // serv_unique_id_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_unique_id_service->setParallelTasksPerInst(std::stoi(configServices.find("unique_id_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_unique_id_service->setExecRatio(std::stod(configServices.find("unique_id_service")->second.at(1)));
-    serv_unique_id_service->setOutputFunction(return_unique_id_service);
-    serv_unique_id_service->setExecAmountFunc(pr_unique_id_service);
-    serv_unique_id_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
-    serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_unique_id_service", simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)), [serv_unique_id_service] { serv_unique_id_service->run(); });
+      // create ETM for service user_service
+      std::vector<std::string> v_serv_user_service = std::vector<std::string>();
+      v_serv_user_service.push_back("user_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_service", v_serv_user_service);
+      serv_user_service->setBootDuration(0);
+      // serv_user_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_user_service->setParallelTasksPerInst(std::stoi(configServices.find("user_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_user_service->setExecRatio(std::stod(configServices.find("user_service")->second.at(1)));
+      serv_user_service->setOutputFunction(return_user_service);
+      serv_user_service->setExecAmountFunc(pr_user_service);
+      serv_user_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
+      serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_user_service", simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)), [serv_user_service]
+                                  { serv_user_service->run(); });
 
+      // create ETM for service text_service
+      std::vector<std::string> v_serv_text_service = std::vector<std::string>();
+      v_serv_text_service.push_back("text_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_text_service = std::make_shared<sg_microserv::ElasticTaskManager>("text_service", v_serv_text_service);
+      serv_text_service->setBootDuration(0);
+      // serv_text_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_text_service->setParallelTasksPerInst(std::stoi(configServices.find("text_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_text_service->setExecRatio(std::stod(configServices.find("text_service")->second.at(1)));
+      serv_text_service->setOutputFunction(return_text_service);
+      serv_text_service->setExecAmountFunc(pr_text_service);
+      serv_text_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
+      serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_text_service", simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)), [serv_text_service]
+                                  { serv_text_service->run(); });
 
-    // create ETM for service media_service
-    std::vector<std::string> v_serv_media_service = std::vector<std::string>();
-    v_serv_media_service.push_back("media_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_media_service = std::make_shared<sg_microserv::ElasticTaskManager>("media_service",v_serv_media_service);
-    serv_media_service->setBootDuration(0);
-    // serv_media_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_media_service->setParallelTasksPerInst(std::stoi(configServices.find("media_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_media_service->setExecRatio(std::stod(configServices.find("media_service")->second.at(1)));
-    serv_media_service->setOutputFunction(return_media_service);
-    serv_media_service->setExecAmountFunc(pr_media_service);
-    serv_media_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
-    serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_media_service", simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)), [serv_media_service] { serv_media_service->run(); });
+      // create ETM for service user_mention_service
+      std::vector<std::string> v_serv_user_mention_service = std::vector<std::string>();
+      v_serv_user_mention_service.push_back("user_mention_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_mention_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_mention_service", v_serv_user_mention_service);
+      serv_user_mention_service->setBootDuration(0);
+      // serv_user_mention_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_user_mention_service->setParallelTasksPerInst(std::stoi(configServices.find("user_mention_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_user_mention_service->setExecRatio(std::stod(configServices.find("user_mention_service")->second.at(1)));
+      serv_user_mention_service->setOutputFunction(return_user_mention_service);
+      serv_user_mention_service->setExecAmountFunc(pr_user_mention_service);
+      serv_user_mention_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
+      serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_user_mention_service", simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)), [serv_user_mention_service]
+                                  { serv_user_mention_service->run(); });
 
+      // create ETM for service home_timeline_service
+      std::vector<std::string> v_serv_home_timeline_service = std::vector<std::string>();
+      v_serv_home_timeline_service.push_back("home_timeline_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_home_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("home_timeline_service", v_serv_home_timeline_service);
+      serv_home_timeline_service->setBootDuration(0);
+      // serv_home_timeline_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_home_timeline_service->setParallelTasksPerInst(std::stoi(configServices.find("home_timeline_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_home_timeline_service->setExecRatio(std::stod(configServices.find("home_timeline_service")->second.at(1)));
+      serv_home_timeline_service->setOutputFunction(return_home_timeline_service);
+      serv_home_timeline_service->setExecAmountFunc(pr_home_timeline_service);
+      serv_home_timeline_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
+      serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_home_timeline_service", simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)), [serv_home_timeline_service]
+                                  { serv_home_timeline_service->run(); });
 
-    // create ETM for service user_service
-    std::vector<std::string> v_serv_user_service = std::vector<std::string>();
-    v_serv_user_service.push_back("user_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_service",v_serv_user_service);
-    serv_user_service->setBootDuration(0);
-    // serv_user_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_user_service->setParallelTasksPerInst(std::stoi(configServices.find("user_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_user_service->setExecRatio(std::stod(configServices.find("user_service")->second.at(1)));
-    serv_user_service->setOutputFunction(return_user_service);
-    serv_user_service->setExecAmountFunc(pr_user_service);
-    serv_user_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
-    serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_user_service", simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)), [serv_user_service] { serv_user_service->run(); });
+      // create ETM for service social_graph_service
+      std::vector<std::string> v_serv_social_graph_service = std::vector<std::string>();
+      v_serv_social_graph_service.push_back("social_graph_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_social_graph_service = std::make_shared<sg_microserv::ElasticTaskManager>("social_graph_service", v_serv_social_graph_service);
+      serv_social_graph_service->setBootDuration(0);
+      // serv_social_graph_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_social_graph_service->setParallelTasksPerInst(std::stoi(configServices.find("social_graph_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_social_graph_service->setExecRatio(std::stod(configServices.find("social_graph_service")->second.at(1)));
+      serv_social_graph_service->setOutputFunction(return_social_graph_service);
+      serv_social_graph_service->setExecAmountFunc(pr_social_graph_service);
+      serv_social_graph_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
+      serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_social_graph_service", simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)), [serv_social_graph_service]
+                                  { serv_social_graph_service->run(); });
 
+      // create ETM for service user_timeline_service
+      std::vector<std::string> v_serv_user_timeline_service = std::vector<std::string>();
+      v_serv_user_timeline_service.push_back("user_timeline_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_timeline_service", v_serv_user_timeline_service);
+      serv_user_timeline_service->setBootDuration(0);
+      // serv_user_timeline_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_user_timeline_service->setParallelTasksPerInst(std::stoi(configServices.find("user_timeline_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_user_timeline_service->setExecRatio(std::stod(configServices.find("user_timeline_service")->second.at(1)));
+      serv_user_timeline_service->setOutputFunction(return_user_timeline_service);
+      serv_user_timeline_service->setExecAmountFunc(pr_user_timeline_service);
+      serv_user_timeline_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
+      serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_user_timeline_service", simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)), [serv_user_timeline_service]
+                                  { serv_user_timeline_service->run(); });
 
-    // create ETM for service text_service
-    std::vector<std::string> v_serv_text_service = std::vector<std::string>();
-    v_serv_text_service.push_back("text_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_text_service = std::make_shared<sg_microserv::ElasticTaskManager>("text_service",v_serv_text_service);
-    serv_text_service->setBootDuration(0);
-    // serv_text_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_text_service->setParallelTasksPerInst(std::stoi(configServices.find("text_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_text_service->setExecRatio(std::stod(configServices.find("text_service")->second.at(1)));
-    serv_text_service->setOutputFunction(return_text_service);
-    serv_text_service->setExecAmountFunc(pr_text_service);
-    serv_text_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
-    serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_text_service", simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)), [serv_text_service] { serv_text_service->run(); });
+      // create ETM for service post_storage_service
+      std::vector<std::string> v_serv_post_storage_service = std::vector<std::string>();
+      v_serv_post_storage_service.push_back("post_storage_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_post_storage_service = std::make_shared<sg_microserv::ElasticTaskManager>("post_storage_service", v_serv_post_storage_service);
+      serv_post_storage_service->setBootDuration(0);
+      // serv_post_storage_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_post_storage_service->setParallelTasksPerInst(std::stoi(configServices.find("post_storage_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_post_storage_service->setExecRatio(std::stod(configServices.find("post_storage_service")->second.at(1)));
+      serv_post_storage_service->setOutputFunction(return_post_storage_service);
+      serv_post_storage_service->setExecAmountFunc(pr_post_storage_service);
+      serv_post_storage_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
+      serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_post_storage_service", simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)), [serv_post_storage_service]
+                                  { serv_post_storage_service->run(); });
 
+      // create ETM for service url_shorten_service
+      std::vector<std::string> v_serv_url_shorten_service = std::vector<std::string>();
+      v_serv_url_shorten_service.push_back("url_shorten_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_url_shorten_service = std::make_shared<sg_microserv::ElasticTaskManager>("url_shorten_service", v_serv_url_shorten_service);
+      serv_url_shorten_service->setBootDuration(0);
+      // serv_url_shorten_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+      // modify this value in the configuration file (parDeg)
+      serv_url_shorten_service->setParallelTasksPerInst(std::stoi(configServices.find("url_shorten_service")->second.at(2)));
+      // modify this value in the  configuration file (execRatio)
+      serv_url_shorten_service->setExecRatio(std::stod(configServices.find("url_shorten_service")->second.at(1)));
+      serv_url_shorten_service->setOutputFunction(return_url_shorten_service);
+      serv_url_shorten_service->setExecAmountFunc(pr_url_shorten_service);
+      serv_url_shorten_service->setReqNames(reqTypeToStr);
+      // set the host location in the config file (location)
+      serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
+      serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
+      simgrid::s4u::Actor::create("etm_url_shorten_service", simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)), [serv_url_shorten_service]
+                                  { serv_url_shorten_service->run(); });
 
-    // create ETM for service user_mention_service
-    std::vector<std::string> v_serv_user_mention_service = std::vector<std::string>();
-    v_serv_user_mention_service.push_back("user_mention_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_mention_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_mention_service",v_serv_user_mention_service);
-    serv_user_mention_service->setBootDuration(0);
-    // serv_user_mention_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_user_mention_service->setParallelTasksPerInst(std::stoi(configServices.find("user_mention_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_user_mention_service->setExecRatio(std::stod(configServices.find("user_mention_service")->second.at(1)));
-    serv_user_mention_service->setOutputFunction(return_user_mention_service);
-    serv_user_mention_service->setExecAmountFunc(pr_user_mention_service);
-    serv_user_mention_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
-    serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_user_mention_service", simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)), [serv_user_mention_service] { serv_user_mention_service->run(); });
+      /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
+      DataSourceFixedInterval *dsf = new DataSourceFixedInterval("nginx_web_server", RequestType::COMPOSE, 1 / freq, 100);
+      simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("clemth.irisa.fr"), [&]
+                                                                 { dsf->run(); });
 
-
-    // create ETM for service home_timeline_service
-    std::vector<std::string> v_serv_home_timeline_service = std::vector<std::string>();
-    v_serv_home_timeline_service.push_back("home_timeline_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_home_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("home_timeline_service",v_serv_home_timeline_service);
-    serv_home_timeline_service->setBootDuration(0);
-    // serv_home_timeline_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_home_timeline_service->setParallelTasksPerInst(std::stoi(configServices.find("home_timeline_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_home_timeline_service->setExecRatio(std::stod(configServices.find("home_timeline_service")->second.at(1)));
-    serv_home_timeline_service->setOutputFunction(return_home_timeline_service);
-    serv_home_timeline_service->setExecAmountFunc(pr_home_timeline_service);
-    serv_home_timeline_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
-    serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_home_timeline_service", simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)), [serv_home_timeline_service] { serv_home_timeline_service->run(); });
-
-
-    // create ETM for service social_graph_service
-    std::vector<std::string> v_serv_social_graph_service = std::vector<std::string>();
-    v_serv_social_graph_service.push_back("social_graph_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_social_graph_service = std::make_shared<sg_microserv::ElasticTaskManager>("social_graph_service",v_serv_social_graph_service);
-    serv_social_graph_service->setBootDuration(0);
-    // serv_social_graph_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_social_graph_service->setParallelTasksPerInst(std::stoi(configServices.find("social_graph_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_social_graph_service->setExecRatio(std::stod(configServices.find("social_graph_service")->second.at(1)));
-    serv_social_graph_service->setOutputFunction(return_social_graph_service);
-    serv_social_graph_service->setExecAmountFunc(pr_social_graph_service);
-    serv_social_graph_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
-    serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_social_graph_service", simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)), [serv_social_graph_service] { serv_social_graph_service->run(); });
-
-
-    // create ETM for service user_timeline_service
-    std::vector<std::string> v_serv_user_timeline_service = std::vector<std::string>();
-    v_serv_user_timeline_service.push_back("user_timeline_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_timeline_service",v_serv_user_timeline_service);
-    serv_user_timeline_service->setBootDuration(0);
-    // serv_user_timeline_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_user_timeline_service->setParallelTasksPerInst(std::stoi(configServices.find("user_timeline_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_user_timeline_service->setExecRatio(std::stod(configServices.find("user_timeline_service")->second.at(1)));
-    serv_user_timeline_service->setOutputFunction(return_user_timeline_service);
-    serv_user_timeline_service->setExecAmountFunc(pr_user_timeline_service);
-    serv_user_timeline_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
-    serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_user_timeline_service", simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)), [serv_user_timeline_service] { serv_user_timeline_service->run(); });
-
-
-    // create ETM for service post_storage_service
-    std::vector<std::string> v_serv_post_storage_service = std::vector<std::string>();
-    v_serv_post_storage_service.push_back("post_storage_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_post_storage_service = std::make_shared<sg_microserv::ElasticTaskManager>("post_storage_service",v_serv_post_storage_service);
-    serv_post_storage_service->setBootDuration(0);
-    // serv_post_storage_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_post_storage_service->setParallelTasksPerInst(std::stoi(configServices.find("post_storage_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_post_storage_service->setExecRatio(std::stod(configServices.find("post_storage_service")->second.at(1)));
-    serv_post_storage_service->setOutputFunction(return_post_storage_service);
-    serv_post_storage_service->setExecAmountFunc(pr_post_storage_service);
-    serv_post_storage_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
-    serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_post_storage_service", simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)), [serv_post_storage_service] { serv_post_storage_service->run(); });
-
-
-    // create ETM for service url_shorten_service
-    std::vector<std::string> v_serv_url_shorten_service = std::vector<std::string>();
-    v_serv_url_shorten_service.push_back("url_shorten_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_url_shorten_service = std::make_shared<sg_microserv::ElasticTaskManager>("url_shorten_service",v_serv_url_shorten_service);
-    serv_url_shorten_service->setBootDuration(0);
-    // serv_url_shorten_service->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_url_shorten_service->setParallelTasksPerInst(std::stoi(configServices.find("url_shorten_service")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_url_shorten_service->setExecRatio(std::stod(configServices.find("url_shorten_service")->second.at(1)));
-    serv_url_shorten_service->setOutputFunction(return_url_shorten_service);
-    serv_url_shorten_service->setExecAmountFunc(pr_url_shorten_service);
-    serv_url_shorten_service->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
-    serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_url_shorten_service", simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)), [serv_url_shorten_service] { serv_url_shorten_service->run(); });
-
-  /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
-  DataSourceFixedInterval* dsf = new DataSourceFixedInterval("nginx_web_server",RequestType::COMPOSE, 1/freq,100);
-  simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("clemth.irisa.fr"), [&]{dsf->run();});
-
-  // kill policies and ETMs
-  simgrid::s4u::this_actor::sleep_for(30); /*set it according to your needs*/
-  XBT_INFO("Done. Killing policies and etms");
-  try {
-      dataS->kill();
-    serv_nginx_web_server->kill();
-    serv_compose_post_service->kill();
-    serv_unique_id_service->kill();
-    serv_media_service->kill();
-    serv_user_service->kill();
-    serv_text_service->kill();
-    serv_user_mention_service->kill();
-    serv_home_timeline_service->kill();
-    serv_social_graph_service->kill();
-    serv_user_timeline_service->kill();
-    serv_post_storage_service->kill();
-    serv_url_shorten_service->kill();
-          }
-catch (simgrid::NetworkFailureException e) {std::cout << "netowrkexecption"<<std::endl;}
+      // kill policies and ETMs
+      simgrid::s4u::this_actor::sleep_for(30); /*set it according to your needs*/
+      XBT_INFO("Done. Killing policies and etms");
+      try
+      {
+            dataS->kill();
+            serv_nginx_web_server->kill();
+            serv_compose_post_service->kill();
+            serv_unique_id_service->kill();
+            serv_media_service->kill();
+            serv_user_service->kill();
+            serv_text_service->kill();
+            serv_user_mention_service->kill();
+            serv_home_timeline_service->kill();
+            serv_social_graph_service->kill();
+            serv_user_timeline_service->kill();
+            serv_post_storage_service->kill();
+            serv_url_shorten_service->kill();
+      }
+      catch (simgrid::NetworkFailureException e)
+      {
+            std::cout << "netowrkexecption" << std::endl;
+      }
 }
-int main(int argc, char* argv[]) {
-  if(argc <= 2){
-    std::cout << "Wrong execution line" << std::endl;
-		std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv>" << std::endl;
-		exit(1);
-	}
+int main(int argc, char *argv[])
+{
+      if (argc <= 2)
+      {
+            std::cout << "Wrong execution line" << std::endl;
+            std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv>" << std::endl;
+            exit(1);
+      }
 
-  // read the config from the file provided by the user
-  std::ifstream input(argv[2]);
-  std::map<std::string, std::vector<std::string>> servConfig;
-  std::string v;
-  // pass header
-  input>>v>>v>>v>>v;
-  for (std::string servName, servLocation, servExecRatio, servParDeg; input >> servName >> servLocation >> servExecRatio >> servParDeg;) {
-        servConfig[servName] = {servLocation, servExecRatio, servParDeg};
-  }
+      // read the config from the file provided by the user
+      std::ifstream input(argv[2]);
+      std::map<std::string, std::vector<std::string>> servConfig;
+      std::string v;
+      // pass header
+      input >> v >> v >> v >> v;
+      for (std::string servName, servLocation, servExecRatio, servParDeg; input >> servName >> servLocation >> servExecRatio >> servParDeg;)
+      {
+            servConfig[servName] = {servLocation, servExecRatio, servParDeg};
+      }
 
-	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
-	e->load_platform(argv[1]);
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]{run(servConfig, std::stod(argv[3]));});
-	e->run();
-	return 0;
+      simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
+      e->load_platform(argv[1]);
+      simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
+                                  { run(servConfig, std::stod(argv[3])); });
+      e->run();
+      return 0;
 }

--- a/examples/generated_2inst.cpp
+++ b/examples/generated_2inst.cpp
@@ -770,7 +770,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
       serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)), [serv_nginx_web_server]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_nginx_web_server", simgrid::s4u::Host::by_name(configServices.find("nginx_web_server")->second.at(0)), [serv_nginx_web_server]
                                   { serv_nginx_web_server->run(); });
 
       // create ETM for service compose_post_service
@@ -789,7 +789,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
       serv_compose_post_service->addHost(simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_compose_post_service", simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)), [serv_compose_post_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_compose_post_service", simgrid::s4u::Host::by_name(configServices.find("compose_post_service")->second.at(0)), [serv_compose_post_service]
                                   { serv_compose_post_service->run(); });
 
       // create ETM for service unique_id_service
@@ -808,7 +808,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
       serv_unique_id_service->addHost(simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_unique_id_service", simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)), [serv_unique_id_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_unique_id_service", simgrid::s4u::Host::by_name(configServices.find("unique_id_service")->second.at(0)), [serv_unique_id_service]
                                   { serv_unique_id_service->run(); });
 
       // create ETM for service media_service
@@ -827,7 +827,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
       serv_media_service->addHost(simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_media_service", simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)), [serv_media_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_media_service", simgrid::s4u::Host::by_name(configServices.find("media_service")->second.at(0)), [serv_media_service]
                                   { serv_media_service->run(); });
 
       // create ETM for service user_service
@@ -846,7 +846,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
       serv_user_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_user_service", simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)), [serv_user_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_user_service", simgrid::s4u::Host::by_name(configServices.find("user_service")->second.at(0)), [serv_user_service]
                                   { serv_user_service->run(); });
 
       // create ETM for service text_service
@@ -865,7 +865,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
       serv_text_service->addHost(simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_text_service", simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)), [serv_text_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_text_service", simgrid::s4u::Host::by_name(configServices.find("text_service")->second.at(0)), [serv_text_service]
                                   { serv_text_service->run(); });
 
       // create ETM for service user_mention_service
@@ -884,7 +884,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
       serv_user_mention_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_user_mention_service", simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)), [serv_user_mention_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_user_mention_service", simgrid::s4u::Host::by_name(configServices.find("user_mention_service")->second.at(0)), [serv_user_mention_service]
                                   { serv_user_mention_service->run(); });
 
       // create ETM for service home_timeline_service
@@ -903,7 +903,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
       serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_home_timeline_service", simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)), [serv_home_timeline_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_home_timeline_service", simgrid::s4u::Host::by_name(configServices.find("home_timeline_service")->second.at(0)), [serv_home_timeline_service]
                                   { serv_home_timeline_service->run(); });
 
       // create ETM for service social_graph_service
@@ -922,7 +922,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
       serv_social_graph_service->addHost(simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_social_graph_service", simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)), [serv_social_graph_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_social_graph_service", simgrid::s4u::Host::by_name(configServices.find("social_graph_service")->second.at(0)), [serv_social_graph_service]
                                   { serv_social_graph_service->run(); });
 
       // create ETM for service user_timeline_service
@@ -941,7 +941,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
       serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_user_timeline_service", simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)), [serv_user_timeline_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_user_timeline_service", simgrid::s4u::Host::by_name(configServices.find("user_timeline_service")->second.at(0)), [serv_user_timeline_service]
                                   { serv_user_timeline_service->run(); });
 
       // create ETM for service post_storage_service
@@ -960,7 +960,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
       serv_post_storage_service->addHost(simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_post_storage_service", simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)), [serv_post_storage_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_post_storage_service", simgrid::s4u::Host::by_name(configServices.find("post_storage_service")->second.at(0)), [serv_post_storage_service]
                                   { serv_post_storage_service->run(); });
 
       // create ETM for service url_shorten_service
@@ -979,12 +979,12 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
       // set the host location in the config file (location)
       serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
       serv_url_shorten_service->addHost(simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)));
-      simgrid::s4u::Actor::create("etm_url_shorten_service", simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)), [serv_url_shorten_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_url_shorten_service", simgrid::s4u::Host::by_name(configServices.find("url_shorten_service")->second.at(0)), [serv_url_shorten_service]
                                   { serv_url_shorten_service->run(); });
 
       /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
       DataSourceFixedInterval *dsf = new DataSourceFixedInterval("nginx_web_server", RequestType::COMPOSE, 1 / freq, 100);
-      simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("clemth.irisa.fr"), [&]
+      simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("clemth.irisa.fr"), [&]
                                                                  { dsf->run(); });
 
       // kill policies and ETMs
@@ -1033,7 +1033,7 @@ int main(int argc, char *argv[])
 
       simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
       e->load_platform(argv[1]);
-      simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
+      simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
                                   { run(servConfig, std::stod(argv[3])); });
       e->run();
       return 0;

--- a/examples/teastore_login.cpp
+++ b/examples/teastore_login.cpp
@@ -13,676 +13,956 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(run_log, "logs of the experiment");
 
 int outSizes(RequestType, std::string);
 /* RETURN FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
-    void return_REQ(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service REQ");
-      switch (td->requestType)
-      {
-case RequestType::LOGIN:
-      if (td->nbHops == 1) {
-        XBT_DEBUG("Output Function for REQ (PARALLEL CHILDS)");
-        std::vector<simgrid::s4u::CommPtr> comV;
-        simgrid::s4u::CommPtr com;
+void return_REQ(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service REQ");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN:
+    if (td->nbHops == 1)
+    {
+      XBT_DEBUG("Output Function for REQ (PARALLEL CHILDS)");
+      ActivitySet commV;
+      simgrid::s4u::CommPtr com;
 
-          XBT_DEBUG("Put to servA");
-          s4u_Mailbox* m_servA = s4u_Mailbox::by_name("servA");
-          sg_microserv::TaskDescription* td_0 = new sg_microserv::TaskDescription(*td);
-          td_0->requestType = RequestType::LOGIN_0;
-          com = m_servA->put_async(td_0, outSizes(td_0->requestType, "servA"));
-          comV.push_back(com);
+      XBT_DEBUG("Put to servA");
+      s4u_Mailbox *m_servA = s4u_Mailbox::by_name("servA");
+      sg_microserv::TaskDescription *td_0 = new sg_microserv::TaskDescription(*td);
+      td_0->requestType = RequestType::LOGIN_0;
+      com = m_servA->put_async(td_0, outSizes(td_0->requestType, "servA"));
+      commV.push(com);
 
-          XBT_DEBUG("Put to servA2");
-          s4u_Mailbox* m_servA2 = s4u_Mailbox::by_name("servA2");
-          sg_microserv::TaskDescription* td_1 = new sg_microserv::TaskDescription(*td);
-          td_1->requestType = RequestType::LOGIN_1;
-          com = m_servA2->put_async(td_1, outSizes(td_1->requestType, "servA2"));
-          comV.push_back(com);
-
-simgrid::s4u::Comm::wait_all(&comV); // wait for communications to finish
-break;
+      XBT_DEBUG("Put to servA2");
+      s4u_Mailbox *m_servA2 = s4u_Mailbox::by_name("servA2");
+      sg_microserv::TaskDescription *td_1 = new sg_microserv::TaskDescription(*td);
+      td_1->requestType = RequestType::LOGIN_1;
+      com = m_servA2->put_async(td_1, outSizes(td_1->requestType, "servA2"));
+      commV.push(com);
+      commV.wait_all();
+      break;
+    }
+  }
 }
-	}
+void return_servA(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servA");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_0:
+    if (td->nbHops == 2)
+    {
+      XBT_DEBUG("Output Function for servA (PARALLEL CHILDS)");
+      ActivitySet commV;
+      simgrid::s4u::CommPtr com;
+
+      XBT_DEBUG("Put to servB");
+      s4u_Mailbox *m_servB = s4u_Mailbox::by_name("servB");
+      sg_microserv::TaskDescription *td_0 = new sg_microserv::TaskDescription(*td);
+      td_0->requestType = RequestType::LOGIN_0_0;
+      com = m_servB->put_async(td_0, outSizes(td_0->requestType, "servB"));
+      commV.push(com);
+
+      XBT_DEBUG("Put to servD");
+      s4u_Mailbox *m_servD = s4u_Mailbox::by_name("servD");
+      sg_microserv::TaskDescription *td_1 = new sg_microserv::TaskDescription(*td);
+      td_1->requestType = RequestType::LOGIN_0_1;
+      com = m_servD->put_async(td_1, outSizes(td_1->requestType, "servD"));
+      commV.push(com);
+
+      XBT_DEBUG("Put to servC");
+      s4u_Mailbox *m_servC = s4u_Mailbox::by_name("servC");
+      sg_microserv::TaskDescription *td_2 = new sg_microserv::TaskDescription(*td);
+      td_2->requestType = RequestType::LOGIN_0_2;
+      com = m_servC->put_async(td_2, outSizes(td_2->requestType, "servC"));
+      commV.push(com);
+      commV.wait_all();
+      break;
+    }
+  }
 }
-    void return_servA(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servA");
-      switch (td->requestType)
-      {
-case RequestType::LOGIN_0:
-      if (td->nbHops == 2) {
-        XBT_DEBUG("Output Function for servA (PARALLEL CHILDS)");
-        std::vector<simgrid::s4u::CommPtr> comV;
-        simgrid::s4u::CommPtr com;
+void return_servB(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servB");
+  switch (td->requestType)
+  {
 
-          XBT_DEBUG("Put to servB");
-          s4u_Mailbox* m_servB = s4u_Mailbox::by_name("servB");
-          sg_microserv::TaskDescription* td_0 = new sg_microserv::TaskDescription(*td);
-          td_0->requestType = RequestType::LOGIN_0_0;
-          com = m_servB->put_async(td_0, outSizes(td_0->requestType, "servB"));
-          comV.push_back(com);
-
-          XBT_DEBUG("Put to servD");
-          s4u_Mailbox* m_servD = s4u_Mailbox::by_name("servD");
-          sg_microserv::TaskDescription* td_1 = new sg_microserv::TaskDescription(*td);
-          td_1->requestType = RequestType::LOGIN_0_1;
-          com = m_servD->put_async(td_1, outSizes(td_1->requestType, "servD"));
-          comV.push_back(com);
-
-          XBT_DEBUG("Put to servC");
-          s4u_Mailbox* m_servC = s4u_Mailbox::by_name("servC");
-          sg_microserv::TaskDescription* td_2 = new sg_microserv::TaskDescription(*td);
-          td_2->requestType = RequestType::LOGIN_0_2;
-          com = m_servC->put_async(td_2, outSizes(td_2->requestType, "servC"));
-          comV.push_back(com);
-
-simgrid::s4u::Comm::wait_all(&comV); // wait for communications to finish
-break;
-}
-	}
-}
-    void return_servB(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servB");
-      switch (td->requestType)
-      {
-
-case RequestType::LOGIN_0_0:
-    if (td->nbHops == 3) {
+  case RequestType::LOGIN_0_0:
+    if (td->nbHops == 3)
+    {
       XBT_DEBUG("Output Function servB (FINAL NODE, NO CHILD!)");
       // TODO DELETE
- /*             for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if ((*it)->get() != NULL) {
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }*/
+      /*             for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+       {
+         if ((*it)->get() != NULL) {
+         auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
+         (*it)->get()->Log({{"end",t2.count()}});
+         (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+         (*it)->reset();
+         (*it) == NULL;
+         }
+       }*/
     }
 
-break;
-	}
+    break;
+  }
 }
-    void return_servD(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servD");
-      switch (td->requestType)
-      {
+void return_servD(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servD");
+  switch (td->requestType)
+  {
 
-case RequestType::LOGIN_0_1:
-    if (td->nbHops == 3) {
+  case RequestType::LOGIN_0_1:
+    if (td->nbHops == 3)
+    {
       XBT_DEBUG("Output Function servD (FINAL NODE, NO CHILD!)");
       // TODO DELETE
- /*             for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if ((*it)->get() != NULL) {
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }*/
+      /*             for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+       {
+         if ((*it)->get() != NULL) {
+         auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
+         (*it)->get()->Log({{"end",t2.count()}});
+         (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+         (*it)->reset();
+         (*it) == NULL;
+         }
+       }*/
     }
 
-break;
-	}
+    break;
+  }
 }
-    void return_servC(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servC");
-      switch (td->requestType)
-      {
+void return_servC(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servC");
+  switch (td->requestType)
+  {
 
-case RequestType::LOGIN_0_2:
-    if (td->nbHops == 3) {
+  case RequestType::LOGIN_0_2:
+    if (td->nbHops == 3)
+    {
       XBT_DEBUG("Output Function servC (FINAL NODE, NO CHILD!)");
       // TODO DELETE
-             /* for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+      /* for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+{
+if ((*it)->get() != NULL) {
+auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
+(*it)->get()->Log({{"end",t2.count()}});
+(*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+(*it)->reset();
+(*it) == NULL;
+}
+}*/
+    }
+
+    break;
+  }
+}
+void return_servA2(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servA2");
+  switch (td->requestType)
   {
-    if ((*it)->get() != NULL) {
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
+  case RequestType::LOGIN_1:
+    if (td->nbHops == 2)
+    {
+      XBT_DEBUG("Output Function for LOGIN_1, put to servC2");
+      s4u_Mailbox *m_servC2 = s4u_Mailbox::by_name("servC2");
+      m_servC2->put(td, outSizes(td->requestType, "servC2"));
+
+      break;
     }
-  }*/
+
+  case RequestType::LOGIN_1_1:
+    if (td->nbHops == 4)
+    {
+      XBT_DEBUG("Output Function for LOGIN_1_1, put to servD2");
+      s4u_Mailbox *m_servD2 = s4u_Mailbox::by_name("servD2");
+      m_servD2->put(td, outSizes(td->requestType, "servD2"));
+
+      break;
     }
 
-break;
-	}
+    break;
+  }
 }
-    void return_servA2(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servA2");
-      switch (td->requestType)
-      {
-case RequestType::LOGIN_1:
-      if (td->nbHops == 2) {
-        XBT_DEBUG("Output Function for LOGIN_1, put to servC2");
-        s4u_Mailbox* m_servC2 = s4u_Mailbox::by_name("servC2");
-        m_servC2->put(td, outSizes(td->requestType, "servC2"));
+void return_servC2(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servC2");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_1:
+    if (td->nbHops == 3)
+    {
+      XBT_DEBUG("Output Function for servC2 (PARALLEL CHILDS)");
+      ActivitySet commV;
+      simgrid::s4u::CommPtr com;
 
+      XBT_DEBUG("Put to servC2");
+      s4u_Mailbox *m_servC2 = s4u_Mailbox::by_name("servC2");
+      sg_microserv::TaskDescription *td_0 = new sg_microserv::TaskDescription(*td);
+      td_0->requestType = RequestType::LOGIN_1_0;
+      com = m_servC2->put_async(td_0, outSizes(td_0->requestType, "servC2"));
+      commV.push(com);
 
-break;
-}
+      XBT_DEBUG("Put to servA2");
+      s4u_Mailbox *m_servA2 = s4u_Mailbox::by_name("servA2");
+      sg_microserv::TaskDescription *td_1 = new sg_microserv::TaskDescription(*td);
+      td_1->requestType = RequestType::LOGIN_1_1;
+      com = m_servA2->put_async(td_1, outSizes(td_1->requestType, "servA2"));
+      commV.push(com);
 
+      XBT_DEBUG("Put to servC2");
+      s4u_Mailbox *m_servC2_ = s4u_Mailbox::by_name("servC2");
+      sg_microserv::TaskDescription *td_2 = new sg_microserv::TaskDescription(*td);
+      td_2->requestType = RequestType::LOGIN_1_2;
+      com = m_servC2_->put_async(td_2, outSizes(td_2->requestType, "servC2"));
+      commV.push(com);
 
-case RequestType::LOGIN_1_1:
-      if (td->nbHops == 4) {
-        XBT_DEBUG("Output Function for LOGIN_1_1, put to servD2");
-        s4u_Mailbox* m_servD2 = s4u_Mailbox::by_name("servD2");
-        m_servD2->put(td, outSizes(td->requestType, "servD2"));
+      commV.wait_all(); // wait for communications to finish
+      break;
+    }
 
-
-break;
-}
-
-break;
-	}
-}
-    void return_servC2(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servC2");
-      switch (td->requestType)
-      {
-case RequestType::LOGIN_1:
-      if (td->nbHops == 3) {
-        XBT_DEBUG("Output Function for servC2 (PARALLEL CHILDS)");
-        std::vector<simgrid::s4u::CommPtr> comV;
-        simgrid::s4u::CommPtr com;
-
-          XBT_DEBUG("Put to servC2");
-          s4u_Mailbox* m_servC2 = s4u_Mailbox::by_name("servC2");
-          sg_microserv::TaskDescription* td_0 = new sg_microserv::TaskDescription(*td);
-          td_0->requestType = RequestType::LOGIN_1_0;
-          com = m_servC2->put_async(td_0, outSizes(td_0->requestType, "servC2"));
-          comV.push_back(com);
-
-          XBT_DEBUG("Put to servA2");
-          s4u_Mailbox* m_servA2 = s4u_Mailbox::by_name("servA2");
-          sg_microserv::TaskDescription* td_1 = new sg_microserv::TaskDescription(*td);
-          td_1->requestType = RequestType::LOGIN_1_1;
-          com = m_servA2->put_async(td_1, outSizes(td_1->requestType, "servA2"));
-          comV.push_back(com);
-
-          XBT_DEBUG("Put to servC2");
-          s4u_Mailbox* m_servC2_ = s4u_Mailbox::by_name("servC2");
-          sg_microserv::TaskDescription* td_2 = new sg_microserv::TaskDescription(*td);
-          td_2->requestType = RequestType::LOGIN_1_2;
-          com = m_servC2_->put_async(td_2, outSizes(td_2->requestType, "servC2"));
-          comV.push_back(com);
-
-simgrid::s4u::Comm::wait_all(&comV); // wait for communications to finish
-break;
-}
-
-
-
-case RequestType::LOGIN_1_0:
-    if (td->nbHops == 4) {
+  case RequestType::LOGIN_1_0:
+    if (td->nbHops == 4)
+    {
       XBT_DEBUG("Output Function servC2 (FINAL NODE, NO CHILD!)");
-       XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock()-td->firstArrivalDate);
+      XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock() - td->firstArrivalDate);
       // TODO DELETE
-    /*          for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if ((*it)->get() != NULL) {
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }*/
-    }
-
-break;
-
-
-
-case RequestType::LOGIN_1_2:
-    if (td->nbHops == 4) {
-      XBT_DEBUG("Output Function servC2 (FINAL NODE, NO CHILD!)");
-      // TODO DELETE
-   /*           for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if ((*it)->get() != NULL) {
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }*/
-    }
-
-break;
-	}
-}
-    void return_servD2(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("Return function of service servD2");
-      switch (td->requestType)
-      {
-case RequestType::LOGIN_1_1:
-      if (td->nbHops == 5) {
-   /*     XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock()-td->firstArrivalDate);
-        XBT_DEBUG("Output Function for LOGIN_1_1, Final service, DELETE");
-        for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if ((*it)->get() != NULL) {
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }*/
-        //delete td;
+      /*          for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+    {
+      if ((*it)->get() != NULL) {
+      auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
+      (*it)->get()->Log({{"end",t2.count()}});
+      (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+      (*it)->reset();
+      (*it) == NULL;
       }
+    }*/
+    }
 
-break;
-	}
+    break;
+
+  case RequestType::LOGIN_1_2:
+    if (td->nbHops == 4)
+    {
+      XBT_DEBUG("Output Function servC2 (FINAL NODE, NO CHILD!)");
+      // TODO DELETE
+      /*           for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+     {
+       if ((*it)->get() != NULL) {
+       auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
+       (*it)->get()->Log({{"end",t2.count()}});
+       (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+       (*it)->reset();
+       (*it) == NULL;
+       }
+     }*/
+    }
+
+    break;
+  }
+}
+void return_servD2(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("Return function of service servD2");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_1_1:
+    if (td->nbHops == 5)
+    {
+      /*     XBT_INFO("FINISHED REQUEST at ts %lf arr: %lf dur: %lf", simgrid::s4u::Engine::get_clock(), td->firstArrivalDate, simgrid::s4u::Engine::get_clock()-td->firstArrivalDate);
+           XBT_DEBUG("Output Function for LOGIN_1_1, Final service, DELETE");
+           for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+     {
+       if ((*it)->get() != NULL) {
+       auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
+       (*it)->get()->Log({{"end",t2.count()}});
+       (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+       (*it)->reset();
+       (*it) == NULL;
+       }
+     }*/
+      // delete td;
+    }
+
+    break;
+  }
 }
 /* PR FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
-    double pr_REQ(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service REQ");
-      switch (td->requestType) {
-case RequestType::LOGIN:
-      if (td->nbHops == 1) {XBT_DEBUG("Entered cost Function for REQ"); return 0;
+double pr_REQ(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service REQ");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN:
+    if (td->nbHops == 1)
+    {
+      XBT_DEBUG("Entered cost Function for REQ");
+      return 0;
+    }
+    break;
+
+  } // it should never end up here
+  return -1;
 }
-break;
+double pr_servA(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servA");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_0:
+    if (td->nbHops == 2)
+    {
+      XBT_DEBUG("Entered cost Function for servA");
+      return 7043000;
+    }
+    break;
 
-      	}//it should never end up here
-return -1;
+  } // it should never end up here
+  return -1;
 }
-    double pr_servA(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servA");
-      switch (td->requestType) {
-case RequestType::LOGIN_0:
-      if (td->nbHops == 2) {XBT_DEBUG("Entered cost Function for servA"); return 7043000;
+double pr_servB(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servB");
+  switch (td->requestType)
+  {
+
+  case RequestType::LOGIN_0_0:
+    if (td->nbHops == 3)
+    {
+      XBT_DEBUG("Entered cost Function for servB");
+      return 57000;
+    }
+
+    break;
+  } // it should never end up here
+  return -1;
 }
-break;
+double pr_servD(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servD");
+  switch (td->requestType)
+  {
 
-      	}//it should never end up here
-return -1;
+  case RequestType::LOGIN_0_1:
+    if (td->nbHops == 3)
+    {
+      XBT_DEBUG("Entered cost Function for servD");
+      return 189000;
+    }
+
+    break;
+  } // it should never end up here
+  return -1;
 }
-    double pr_servB(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servB");
-      switch (td->requestType) {
+double pr_servC(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servC");
+  switch (td->requestType)
+  {
 
-case RequestType::LOGIN_0_0:
-    if (td->nbHops == 3) {XBT_DEBUG("Entered cost Function for servB"); return 57000;}
+  case RequestType::LOGIN_0_2:
+    if (td->nbHops == 3)
+    {
+      XBT_DEBUG("Entered cost Function for servC");
+      return 542000;
+    }
 
-break;
-	}//it should never end up here
-return -1;
+    break;
+  } // it should never end up here
+  return -1;
 }
-    double pr_servD(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servD");
-      switch (td->requestType) {
+double pr_servA2(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servA2");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_1:
+    if (td->nbHops == 2)
+    {
+      XBT_DEBUG("Entered cost Function for LOGIN_1");
+      return 13891000;
+    }
 
-case RequestType::LOGIN_0_1:
-    if (td->nbHops == 3) {XBT_DEBUG("Entered cost Function for servD"); return 189000;}
+  case RequestType::LOGIN_1_1:
+    if (td->nbHops == 4)
+    {
+      XBT_DEBUG("Entered cost Function for LOGIN_1_1");
+      return 828000;
+    }
 
-break;
-	}//it should never end up here
-return -1;
+    break;
+  } // it should never end up here
+  return -1;
 }
-    double pr_servC(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servC");
-      switch (td->requestType) {
+double pr_servC2(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servC2");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_1:
+    if (td->nbHops == 3)
+    {
+      XBT_DEBUG("Entered cost Function for servC2");
+      return 6073000;
+    }
+    break;
 
-case RequestType::LOGIN_0_2:
-    if (td->nbHops == 3) {XBT_DEBUG("Entered cost Function for servC"); return 542000;}
+  case RequestType::LOGIN_1_0:
+    if (td->nbHops == 4)
+    {
+      XBT_DEBUG("Entered cost Function for servC2");
+      return 4985000;
+    }
 
-break;
-	}//it should never end up here
-return -1;
+    break;
+
+  case RequestType::LOGIN_1_2:
+    if (td->nbHops == 4)
+    {
+      XBT_DEBUG("Entered cost Function for servC2");
+      return 443000;
+    }
+
+    break;
+  } // it should never end up here
+  return -1;
 }
-    double pr_servA2(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servA2");
-      switch (td->requestType) {
-case RequestType::LOGIN_1:
-      if (td->nbHops == 2) {XBT_DEBUG("Entered cost Function for LOGIN_1"); return 13891000;}
+double pr_servD2(sg_microserv::TaskDescription *td)
+{
+  XBT_DEBUG("pr function of service servD2");
+  switch (td->requestType)
+  {
+  case RequestType::LOGIN_1_1:
+    if (td->nbHops == 5)
+    {
+      XBT_DEBUG("Entered cost Function for LOGIN_1_1 (FINAL NODE, NO CHILD!)");
+      return 408000;
+    }
 
-
-case RequestType::LOGIN_1_1:
-      if (td->nbHops == 4) {XBT_DEBUG("Entered cost Function for LOGIN_1_1"); return 828000;}
-
-break;
-	}//it should never end up here
-return -1;
+    break;
+  } // it should never end up here
+  return -1;
 }
-    double pr_servC2(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servC2");
-      switch (td->requestType) {
-case RequestType::LOGIN_1:
-      if (td->nbHops == 3) {XBT_DEBUG("Entered cost Function for servC2"); return 6073000;
+int outSizes(RequestType t, std::string nextServ)
+{
+  switch (t)
+  {
+  case RequestType::LOGIN:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_0:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_0_0:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_0_1:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_0_2:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_1:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_1_0:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_1_1:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  case RequestType::LOGIN_1_2:
+    if (nextServ == "servA")
+    {
+      return 100;
+    }
+    if (nextServ == "servB")
+    {
+      return 100;
+    }
+    if (nextServ == "servD")
+    {
+      return 100;
+    }
+    if (nextServ == "servC")
+    {
+      return 100;
+    }
+    if (nextServ == "servA2")
+    {
+      return 100;
+    }
+    if (nextServ == "servC2")
+    {
+      return 100;
+    }
+    if (nextServ == "servD2")
+    {
+      return 100;
+    }
+    break;
+  }
+  return -1; // WE SHOULD NEVER GET TO THAT POINT
 }
-break;
 
-
-
-
-case RequestType::LOGIN_1_0:
-    if (td->nbHops == 4) {XBT_DEBUG("Entered cost Function for servC2"); return 4985000;}
-
-break;
-
-
-
-case RequestType::LOGIN_1_2:
-    if (td->nbHops == 4) {XBT_DEBUG("Entered cost Function for servC2"); return 443000;}
-
-break;
-	}//it should never end up here
-return -1;
-}
-    double pr_servD2(sg_microserv::TaskDescription* td) {
-      XBT_DEBUG("pr function of service servD2");
-      switch (td->requestType) {
-case RequestType::LOGIN_1_1:
-      if (td->nbHops == 5) {XBT_DEBUG("Entered cost Function for LOGIN_1_1 (FINAL NODE, NO CHILD!)"); return 408000;}
-
-break;
-	}//it should never end up here
-return -1;
-}
-int outSizes(RequestType t, std::string nextServ) {
-    switch (t) {
-	case RequestType::LOGIN :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_0 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_0_0 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_0_1 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_0_2 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_1 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_1_0 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_1_1 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-	case RequestType::LOGIN_1_2 :
-	if (nextServ == "servA") {return 100;}
-	if (nextServ == "servB") {return 100;}
-	if (nextServ == "servD") {return 100;}
-	if (nextServ == "servC") {return 100;}
-	if (nextServ == "servA2") {return 100;}
-	if (nextServ == "servC2") {return 100;}
-	if (nextServ == "servD2") {return 100;}
-	break;
-}return -1; // WE SHOULD NEVER GET TO THAT POINT
+std::string reqTypeToStr(RequestType t)
+{
+  switch (t)
+  {
+  case RequestType::LOGIN:
+    return "LOGIN";
+    break;
+  case RequestType::LOGIN_0:
+    return "LOGIN_0";
+    break;
+  case RequestType::LOGIN_0_0:
+    return "LOGIN_0_0";
+    break;
+  case RequestType::LOGIN_0_1:
+    return "LOGIN_0_1";
+    break;
+  case RequestType::LOGIN_0_2:
+    return "LOGIN_0_2";
+    break;
+  case RequestType::LOGIN_1:
+    return "LOGIN_1";
+    break;
+  case RequestType::LOGIN_1_0:
+    return "LOGIN_1_0";
+    break;
+  case RequestType::LOGIN_1_1:
+    return "LOGIN_1_1";
+    break;
+  case RequestType::LOGIN_1_2:
+    return "LOGIN_1_2";
+    break;
+  }
+  return "WTF";
 }
 
-std::string reqTypeToStr(RequestType t) {
-    switch (t) {
-	case RequestType::LOGIN : return "LOGIN";break;
-	case RequestType::LOGIN_0 : return "LOGIN_0";break;
-	case RequestType::LOGIN_0_0 : return "LOGIN_0_0";break;
-	case RequestType::LOGIN_0_1 : return "LOGIN_0_1";break;
-	case RequestType::LOGIN_0_2 : return "LOGIN_0_2";break;
-	case RequestType::LOGIN_1 : return "LOGIN_1";break;
-	case RequestType::LOGIN_1_0 : return "LOGIN_1_0";break;
-	case RequestType::LOGIN_1_1 : return "LOGIN_1_1";break;
-	case RequestType::LOGIN_1_2 : return "LOGIN_1_2";break;
-}return "WTF";
-}
+void run(std::map<std::string, std::vector<std::string>> configServices, double freq)
+{
+  XBT_INFO("Starting run()");
 
-  void run(std::map<std::string, std::vector<std::string>> configServices, double freq) {
-    XBT_INFO("Starting run()");
+  // create ETM for service REQ
+  std::vector<std::string> v_serv_REQ = std::vector<std::string>();
+  v_serv_REQ.push_back("REQ");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_REQ = std::make_shared<sg_microserv::ElasticTaskManager>("REQ", v_serv_REQ);
+  serv_REQ->setBootDuration(0);
+  // serv_REQ->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_REQ->setParallelTasksPerInst(std::stoi(configServices.find("REQ")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_REQ->setExecRatio(std::stod(configServices.find("REQ")->second.at(1)));
+  serv_REQ->setOutputFunction(return_REQ);
+  serv_REQ->setExecAmountFunc(pr_REQ);
+  serv_REQ->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_REQ->addHost(simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_REQ", simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)), [serv_REQ]
+                              { serv_REQ->run(); });
 
-    // create ETM for service REQ
-    std::vector<std::string> v_serv_REQ = std::vector<std::string>();
-    v_serv_REQ.push_back("REQ");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_REQ = std::make_shared<sg_microserv::ElasticTaskManager>("REQ",v_serv_REQ);
-    serv_REQ->setBootDuration(0);
-    // serv_REQ->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_REQ->setParallelTasksPerInst(std::stoi(configServices.find("REQ")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_REQ->setExecRatio(std::stod(configServices.find("REQ")->second.at(1)));
-    serv_REQ->setOutputFunction(return_REQ);
-    serv_REQ->setExecAmountFunc(pr_REQ);
-    serv_REQ->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_REQ->addHost(simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_REQ", simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)), [serv_REQ] { serv_REQ->run(); });
+  // create ETM for service servA
+  std::vector<std::string> v_serv_servA = std::vector<std::string>();
+  v_serv_servA.push_back("servA");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servA = std::make_shared<sg_microserv::ElasticTaskManager>("servA", v_serv_servA);
+  serv_servA->setBootDuration(0);
+  // serv_servA->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servA->setParallelTasksPerInst(std::stoi(configServices.find("servA")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servA->setExecRatio(std::stod(configServices.find("servA")->second.at(1)));
+  serv_servA->setOutputFunction(return_servA);
+  serv_servA->setExecAmountFunc(pr_servA);
+  serv_servA->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servA->addHost(simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servA", simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)), [serv_servA]
+                              { serv_servA->run(); });
 
+  // create ETM for service servB
+  std::vector<std::string> v_serv_servB = std::vector<std::string>();
+  v_serv_servB.push_back("servB");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servB = std::make_shared<sg_microserv::ElasticTaskManager>("servB", v_serv_servB);
+  serv_servB->setBootDuration(0);
+  // serv_servB->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servB->setParallelTasksPerInst(std::stoi(configServices.find("servB")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servB->setExecRatio(std::stod(configServices.find("servB")->second.at(1)));
+  serv_servB->setOutputFunction(return_servB);
+  serv_servB->setExecAmountFunc(pr_servB);
+  serv_servB->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servB->addHost(simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servB", simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)), [serv_servB]
+                              { serv_servB->run(); });
 
-    // create ETM for service servA
-    std::vector<std::string> v_serv_servA = std::vector<std::string>();
-    v_serv_servA.push_back("servA");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servA = std::make_shared<sg_microserv::ElasticTaskManager>("servA",v_serv_servA);
-    serv_servA->setBootDuration(0);
-    // serv_servA->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servA->setParallelTasksPerInst(std::stoi(configServices.find("servA")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servA->setExecRatio(std::stod(configServices.find("servA")->second.at(1)));
-    serv_servA->setOutputFunction(return_servA);
-    serv_servA->setExecAmountFunc(pr_servA);
-    serv_servA->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servA->addHost(simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servA", simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)), [serv_servA] { serv_servA->run(); });
+  // create ETM for service servD
+  std::vector<std::string> v_serv_servD = std::vector<std::string>();
+  v_serv_servD.push_back("servD");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servD = std::make_shared<sg_microserv::ElasticTaskManager>("servD", v_serv_servD);
+  serv_servD->setBootDuration(0);
+  // serv_servD->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servD->setParallelTasksPerInst(std::stoi(configServices.find("servD")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servD->setExecRatio(std::stod(configServices.find("servD")->second.at(1)));
+  serv_servD->setOutputFunction(return_servD);
+  serv_servD->setExecAmountFunc(pr_servD);
+  serv_servD->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servD->addHost(simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servD", simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)), [serv_servD]
+                              { serv_servD->run(); });
 
+  // create ETM for service servC
+  std::vector<std::string> v_serv_servC = std::vector<std::string>();
+  v_serv_servC.push_back("servC");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servC = std::make_shared<sg_microserv::ElasticTaskManager>("servC", v_serv_servC);
+  serv_servC->setBootDuration(0);
+  // serv_servC->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servC->setParallelTasksPerInst(std::stoi(configServices.find("servC")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servC->setExecRatio(std::stod(configServices.find("servC")->second.at(1)));
+  serv_servC->setOutputFunction(return_servC);
+  serv_servC->setExecAmountFunc(pr_servC);
+  serv_servC->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servC->addHost(simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servC", simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)), [serv_servC]
+                              { serv_servC->run(); });
 
-    // create ETM for service servB
-    std::vector<std::string> v_serv_servB = std::vector<std::string>();
-    v_serv_servB.push_back("servB");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servB = std::make_shared<sg_microserv::ElasticTaskManager>("servB",v_serv_servB);
-    serv_servB->setBootDuration(0);
-    // serv_servB->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servB->setParallelTasksPerInst(std::stoi(configServices.find("servB")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servB->setExecRatio(std::stod(configServices.find("servB")->second.at(1)));
-    serv_servB->setOutputFunction(return_servB);
-    serv_servB->setExecAmountFunc(pr_servB);
-    serv_servB->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servB->addHost(simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servB", simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)), [serv_servB] { serv_servB->run(); });
+  // create ETM for service servA2
+  std::vector<std::string> v_serv_servA2 = std::vector<std::string>();
+  v_serv_servA2.push_back("servA2");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servA2 = std::make_shared<sg_microserv::ElasticTaskManager>("servA2", v_serv_servA2);
+  serv_servA2->setBootDuration(0);
+  // serv_servA2->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servA2->setParallelTasksPerInst(std::stoi(configServices.find("servA2")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servA2->setExecRatio(std::stod(configServices.find("servA2")->second.at(1)));
+  serv_servA2->setOutputFunction(return_servA2);
+  serv_servA2->setExecAmountFunc(pr_servA2);
+  serv_servA2->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servA2->addHost(simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servA2", simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)), [serv_servA2]
+                              { serv_servA2->run(); });
 
+  // create ETM for service servC2
+  std::vector<std::string> v_serv_servC2 = std::vector<std::string>();
+  v_serv_servC2.push_back("servC2");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servC2 = std::make_shared<sg_microserv::ElasticTaskManager>("servC2", v_serv_servC2);
+  serv_servC2->setBootDuration(0);
+  // serv_servC2->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servC2->setParallelTasksPerInst(std::stoi(configServices.find("servC2")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servC2->setExecRatio(std::stod(configServices.find("servC2")->second.at(1)));
+  serv_servC2->setOutputFunction(return_servC2);
+  serv_servC2->setExecAmountFunc(pr_servC2);
+  serv_servC2->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servC2->addHost(simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servC2", simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)), [serv_servC2]
+                              { serv_servC2->run(); });
 
-    // create ETM for service servD
-    std::vector<std::string> v_serv_servD = std::vector<std::string>();
-    v_serv_servD.push_back("servD");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servD = std::make_shared<sg_microserv::ElasticTaskManager>("servD",v_serv_servD);
-    serv_servD->setBootDuration(0);
-    // serv_servD->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servD->setParallelTasksPerInst(std::stoi(configServices.find("servD")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servD->setExecRatio(std::stod(configServices.find("servD")->second.at(1)));
-    serv_servD->setOutputFunction(return_servD);
-    serv_servD->setExecAmountFunc(pr_servD);
-    serv_servD->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servD->addHost(simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servD", simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)), [serv_servD] { serv_servD->run(); });
-
-
-    // create ETM for service servC
-    std::vector<std::string> v_serv_servC = std::vector<std::string>();
-    v_serv_servC.push_back("servC");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servC = std::make_shared<sg_microserv::ElasticTaskManager>("servC",v_serv_servC);
-    serv_servC->setBootDuration(0);
-    // serv_servC->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servC->setParallelTasksPerInst(std::stoi(configServices.find("servC")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servC->setExecRatio(std::stod(configServices.find("servC")->second.at(1)));
-    serv_servC->setOutputFunction(return_servC);
-    serv_servC->setExecAmountFunc(pr_servC);
-    serv_servC->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servC->addHost(simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servC", simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)), [serv_servC] { serv_servC->run(); });
-
-
-    // create ETM for service servA2
-    std::vector<std::string> v_serv_servA2 = std::vector<std::string>();
-    v_serv_servA2.push_back("servA2");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servA2 = std::make_shared<sg_microserv::ElasticTaskManager>("servA2",v_serv_servA2);
-    serv_servA2->setBootDuration(0);
-    // serv_servA2->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servA2->setParallelTasksPerInst(std::stoi(configServices.find("servA2")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servA2->setExecRatio(std::stod(configServices.find("servA2")->second.at(1)));
-    serv_servA2->setOutputFunction(return_servA2);
-    serv_servA2->setExecAmountFunc(pr_servA2);
-    serv_servA2->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servA2->addHost(simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servA2", simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)), [serv_servA2] { serv_servA2->run(); });
-
-
-    // create ETM for service servC2
-    std::vector<std::string> v_serv_servC2 = std::vector<std::string>();
-    v_serv_servC2.push_back("servC2");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servC2 = std::make_shared<sg_microserv::ElasticTaskManager>("servC2",v_serv_servC2);
-    serv_servC2->setBootDuration(0);
-    // serv_servC2->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servC2->setParallelTasksPerInst(std::stoi(configServices.find("servC2")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servC2->setExecRatio(std::stod(configServices.find("servC2")->second.at(1)));
-    serv_servC2->setOutputFunction(return_servC2);
-    serv_servC2->setExecAmountFunc(pr_servC2);
-    serv_servC2->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servC2->addHost(simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servC2", simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)), [serv_servC2] { serv_servC2->run(); });
-
-
-    // create ETM for service servD2
-    std::vector<std::string> v_serv_servD2 = std::vector<std::string>();
-    v_serv_servD2.push_back("servD2");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servD2 = std::make_shared<sg_microserv::ElasticTaskManager>("servD2",v_serv_servD2);
-    serv_servD2->setBootDuration(0);
-    // serv_servD2->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
-    // modify this value in the configuration file (parDeg)
-    serv_servD2->setParallelTasksPerInst(std::stoi(configServices.find("servD2")->second.at(2)));
-    // modify this value in the  configuration file (execRatio)
-    serv_servD2->setExecRatio(std::stod(configServices.find("servD2")->second.at(1)));
-    serv_servD2->setOutputFunction(return_servD2);
-    serv_servD2->setExecAmountFunc(pr_servD2);
-    serv_servD2->setReqNames(reqTypeToStr);
-    // set the host location in the config file (location)
-    serv_servD2->addHost(simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_servD2", simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)), [serv_servD2] { serv_servD2->run(); });
+  // create ETM for service servD2
+  std::vector<std::string> v_serv_servD2 = std::vector<std::string>();
+  v_serv_servD2.push_back("servD2");
+  std::shared_ptr<sg_microserv::ElasticTaskManager> serv_servD2 = std::make_shared<sg_microserv::ElasticTaskManager>("servD2", v_serv_servD2);
+  serv_servD2->setBootDuration(0);
+  // serv_servD2->setDataSizeRatio(1); NOT USED ANYMORE, KEEP AS COMMENT IN CASE
+  // modify this value in the configuration file (parDeg)
+  serv_servD2->setParallelTasksPerInst(std::stoi(configServices.find("servD2")->second.at(2)));
+  // modify this value in the  configuration file (execRatio)
+  serv_servD2->setExecRatio(std::stod(configServices.find("servD2")->second.at(1)));
+  serv_servD2->setOutputFunction(return_servD2);
+  serv_servD2->setExecAmountFunc(pr_servD2);
+  serv_servD2->setReqNames(reqTypeToStr);
+  // set the host location in the config file (location)
+  serv_servD2->addHost(simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)));
+  simgrid::s4u::Actor::create("etm_servD2", simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)), [serv_servD2]
+                              { serv_servD2->run(); });
 
   /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
   simgrid::s4u::this_actor::sleep_for(1);
-std::vector<simgrid::s4u::CommPtr> pending_comms;
-  simgrid::s4u::Mailbox* mb = s4u_Mailbox::by_name("REQ");
+  std::vector<simgrid::s4u::CommPtr> pending_comms;
+  simgrid::s4u::Mailbox *mb = s4u_Mailbox::by_name("REQ");
   boost::uuids::random_generator generator;
-  for (int i = 0 ; i < freq; i++){
+  for (int i = 0; i < freq; i++)
+  {
     double date = simgrid::s4u::Engine::get_instance()->get_clock();
-    sg_microserv::TaskDescription* t = new sg_microserv::TaskDescription(generator(), date);
+    sg_microserv::TaskDescription *t = new sg_microserv::TaskDescription(generator(), date);
     t->firstArrivalDate = date;
 
     t->dSize = 100;
     t->requestType = RequestType::LOGIN;
 
     simgrid::s4u::CommPtr comm = mb->put_async(t, t->dSize);
-pending_comms.push_back(comm);
+    pending_comms.push_back(comm);
   }
 
-
-simgrid::s4u::this_actor::sleep_for(1);
+  simgrid::s4u::this_actor::sleep_for(1);
 
   // kill policies and ETMs
-  //simgrid::s4u::this_actor::sleep_for(10); /*set it according to your needs*/
+  // simgrid::s4u::this_actor::sleep_for(10); /*set it according to your needs*/
   XBT_INFO("Done. Killing policies and etms");
-    serv_REQ->kill();
-    serv_servA->kill();
-    serv_servB->kill();
-    serv_servD->kill();
-    serv_servC->kill();
-    serv_servA2->kill();
-    serv_servC2->kill();
-    serv_servD2->kill();
+  serv_REQ->kill();
+  serv_servA->kill();
+  serv_servB->kill();
+  serv_servD->kill();
+  serv_servC->kill();
+  serv_servA2->kill();
+  serv_servC2->kill();
+  serv_servD2->kill();
 }
-int main(int argc, char* argv[]) {
-  if (argc <= 2) {
+int main(int argc, char *argv[])
+{
+  if (argc <= 2)
+  {
     std::cout << "Wrong execution line" << std::endl;
-		std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv>" << std::endl;
-		exit(1);
-	}
+    std::cout << argv[0] << "<simgrid-platform-file.xml> <services-config-file.csv>" << std::endl;
+    exit(1);
+  }
 
   // read the config from the file provided by the user
   std::ifstream input(argv[2]);
   std::map<std::string, std::vector<std::string>> servConfig;
   std::string v;
   // pass header
-  input>>v>>v>>v>>v;
-  for (std::string servName, servLocation, servExecRatio, servParDeg; input >> servName >> servLocation >> servExecRatio >> servParDeg;) {
-        servConfig[servName] = {servLocation, servExecRatio, servParDeg};
+  input >> v >> v >> v >> v;
+  for (std::string servName, servLocation, servExecRatio, servParDeg; input >> servName >> servLocation >> servExecRatio >> servParDeg;)
+  {
+    servConfig[servName] = {servLocation, servExecRatio, servParDeg};
   }
 
-	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
+  simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
 
-	e->load_platform(argv[1]);
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&] {run(servConfig, std::stod(argv[3]));});
-	e->run();
-	return 0;
+  e->load_platform(argv[1]);
+  simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
+                              { run(servConfig, std::stod(argv[3])); });
+  e->run();
+  return 0;
 }

--- a/examples/teastore_login.cpp
+++ b/examples/teastore_login.cpp
@@ -777,7 +777,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_REQ->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_REQ->addHost(simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_REQ", simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)), [serv_REQ]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_REQ", simgrid::s4u::Host::by_name(configServices.find("REQ")->second.at(0)), [serv_REQ]
                               { serv_REQ->run(); });
 
   // create ETM for service servA
@@ -795,7 +795,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servA->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servA->addHost(simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servA", simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)), [serv_servA]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servA", simgrid::s4u::Host::by_name(configServices.find("servA")->second.at(0)), [serv_servA]
                               { serv_servA->run(); });
 
   // create ETM for service servB
@@ -813,7 +813,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servB->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servB->addHost(simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servB", simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)), [serv_servB]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servB", simgrid::s4u::Host::by_name(configServices.find("servB")->second.at(0)), [serv_servB]
                               { serv_servB->run(); });
 
   // create ETM for service servD
@@ -831,7 +831,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servD->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servD->addHost(simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servD", simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)), [serv_servD]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servD", simgrid::s4u::Host::by_name(configServices.find("servD")->second.at(0)), [serv_servD]
                               { serv_servD->run(); });
 
   // create ETM for service servC
@@ -849,7 +849,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servC->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servC->addHost(simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servC", simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)), [serv_servC]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servC", simgrid::s4u::Host::by_name(configServices.find("servC")->second.at(0)), [serv_servC]
                               { serv_servC->run(); });
 
   // create ETM for service servA2
@@ -867,7 +867,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servA2->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servA2->addHost(simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servA2", simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)), [serv_servA2]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servA2", simgrid::s4u::Host::by_name(configServices.find("servA2")->second.at(0)), [serv_servA2]
                               { serv_servA2->run(); });
 
   // create ETM for service servC2
@@ -885,7 +885,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servC2->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servC2->addHost(simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servC2", simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)), [serv_servC2]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servC2", simgrid::s4u::Host::by_name(configServices.find("servC2")->second.at(0)), [serv_servC2]
                               { serv_servC2->run(); });
 
   // create ETM for service servD2
@@ -903,7 +903,7 @@ void run(std::map<std::string, std::vector<std::string>> configServices, double 
   serv_servD2->setReqNames(reqTypeToStr);
   // set the host location in the config file (location)
   serv_servD2->addHost(simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)));
-  simgrid::s4u::Actor::create("etm_servD2", simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)), [serv_servD2]
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_servD2", simgrid::s4u::Host::by_name(configServices.find("servD2")->second.at(0)), [serv_servD2]
                               { serv_servD2->run(); });
 
   /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
@@ -961,7 +961,7 @@ int main(int argc, char *argv[])
   simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
 
   e->load_platform(argv[1]);
-  simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
+  simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name(servConfig.find("default")->second.at(0)), [&]
                               { run(servConfig, std::stod(argv[3])); });
   e->run();
   return 0;

--- a/examples/test2req.cpp
+++ b/examples/test2req.cpp
@@ -14,229 +14,275 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(run_log, "logs of the experiment");
 using namespace sg_microserv;
 
 /* RETURN FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
-    void return_nginx_web_server(TaskDescription* td) {
+void return_nginx_web_server(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service nginx_web_server");
       switch (td->requestType)
       {
-case RequestType::READHOME:
-      if(td->nbHops == 1){
-        XBT_DEBUG("Output Function for READHOME, put to home_timeline_service");
-        s4u_Mailbox* m_user_timeline = s4u_Mailbox::by_name("home_timeline_service");
-        m_user_timeline->put(td, td->dSize);
+      case RequestType::READHOME:
+            if (td->nbHops == 1)
+            {
+                  XBT_DEBUG("Output Function for READHOME, put to home_timeline_service");
+                  s4u_Mailbox *m_user_timeline = s4u_Mailbox::by_name("home_timeline_service");
+                  m_user_timeline->put(td, td->dSize);
+            }
+
+            break;
+
+      case RequestType::READUSER:
+            if (td->nbHops == 1)
+            {
+                  XBT_DEBUG("Output Function for READUSER, put to user_timeline_service");
+                  s4u_Mailbox *m_user_timeline = s4u_Mailbox::by_name("user_timeline_service");
+                  m_user_timeline->put(td, td->dSize);
+            }
+
+            break;
       }
-
-break;
-
-case RequestType::READUSER:
-      if(td->nbHops == 1){
-        XBT_DEBUG("Output Function for READUSER, put to user_timeline_service");
-        s4u_Mailbox* m_user_timeline = s4u_Mailbox::by_name("user_timeline_service");
-        m_user_timeline->put(td, td->dSize);
-      }
-
-break;
-	}
 }
-    void return_home_timeline_service(TaskDescription* td) {
+void return_home_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service home_timeline_service");
       switch (td->requestType)
       {
-case RequestType::READHOME:
-      if(td->nbHops == 2){
-        XBT_DEBUG("Output Function for READHOME, put to post_storage_service");
-        s4u_Mailbox* m_user_timeline = s4u_Mailbox::by_name("post_storage_service");
-        m_user_timeline->put(td, td->dSize);
-      }
+      case RequestType::READHOME:
+            if (td->nbHops == 2)
+            {
+                  XBT_DEBUG("Output Function for READHOME, put to post_storage_service");
+                  s4u_Mailbox *m_user_timeline = s4u_Mailbox::by_name("post_storage_service");
+                  m_user_timeline->put(td, td->dSize);
+            }
 
-break;
-	}
+            break;
+      }
 }
-    void return_post_storage_service(TaskDescription* td) {
+void return_post_storage_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service post_storage_service");
       switch (td->requestType)
       {
-case RequestType::READHOME:
-      if(td->nbHops == 3){
-        XBT_DEBUG("Output Function for READHOME, Final service, DELETE");
-        for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if((*it)->get() != NULL){
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }
-        delete td;
-        // TODO DELETE JAEGER SPANS
+      case RequestType::READHOME:
+            #ifdef USE_JAEGERTRACING
+            if (td->nbHops == 3)
+            {
+                  XBT_DEBUG("Output Function for READHOME, Final service, DELETE");
+                  for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+                  {
+                        if ((*it)->get() != NULL)
+                        {
+                              auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+                              (*it)->get()->Log({{"end", t2.count()}});
+                              (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+                              (*it)->reset();
+                              (*it) == NULL;
+                        }
+                  }
+                  delete td;
+                  // TODO DELETE JAEGER SPANS
+            }
+            #endif /*USE_JAEGERTRACING*/
+            break;
+
+      case RequestType::READUSER:
+            #ifdef USE_JAEGERTRACING      
+            if (td->nbHops == 3)
+            {
+                  XBT_DEBUG("Output Function for READUSER, Final service, DELETE");
+                  for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
+                  {
+                        if ((*it)->get() != NULL)
+                        {
+                              auto t2 = std::chrono::seconds(946684800) + std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock() * 1000000));
+                              (*it)->get()->Log({{"end", t2.count()}});
+                              (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
+                              (*it)->reset();
+                              (*it) == NULL;
+                        }
+                  }
+                  delete td;
+                  // TODO DELETE JAEGER SPANS
+            }
+            #endif /*USE_JAEGERTRACING*/
+            break;
       }
-
-break;
-
-case RequestType::READUSER:
-      if(td->nbHops == 3){
-        XBT_DEBUG("Output Function for READUSER, Final service, DELETE");
-        for (auto it = td->parentSpans.rbegin(); it != td->parentSpans.rend(); ++it)
-  {
-    if((*it)->get() != NULL){
-    auto t2 = std::chrono::seconds(946684800)+std::chrono::microseconds(int(simgrid::s4u::Engine::get_instance()->get_clock()*1000000));
-    (*it)->get()->Log({{"end",t2.count()}});
-    (*it)->get()->Finish({opentracing::v3::FinishTimestamp(t2)});
-    (*it)->reset();
-    (*it) == NULL;
-    }
-  }
-        delete td;
-        // TODO DELETE JAEGER SPANS
-      }
-
-break;
-	}
 }
-    void return_user_timeline_service(TaskDescription* td) {
+void return_user_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("Return function of service user_timeline_service");
       switch (td->requestType)
       {
-case RequestType::READUSER:
-      if(td->nbHops == 2){
-        XBT_DEBUG("Output Function for READUSER, put to post_storage_service");
-        s4u_Mailbox* m_user_timeline = s4u_Mailbox::by_name("post_storage_service");
-        m_user_timeline->put(td, td->dSize);
-      }
+      case RequestType::READUSER:
+            if (td->nbHops == 2)
+            {
+                  XBT_DEBUG("Output Function for READUSER, put to post_storage_service");
+                  s4u_Mailbox *m_user_timeline = s4u_Mailbox::by_name("post_storage_service");
+                  m_user_timeline->put(td, td->dSize);
+            }
 
-break;
-	}
+            break;
+      }
 }
 /* PR FUNCTIONS, AUTO GENERATED CODE, MODIFY IF YOU KNOW WHAT YOU WANT */
-    double pr_nginx_web_server(TaskDescription* td) {
+double pr_nginx_web_server(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service nginx_web_server");
       switch (td->requestType)
       {
-case RequestType::READHOME:
-      if(td->nbHops == 1){XBT_DEBUG("Entered cost Function for READHOME"); return 1564000;}
+      case RequestType::READHOME:
+            if (td->nbHops == 1)
+            {
+                  XBT_DEBUG("Entered cost Function for READHOME");
+                  return 1564000;
+            }
 
-break;
+            break;
 
-case RequestType::READUSER:
-      if(td->nbHops == 1){XBT_DEBUG("Entered cost Function for READUSER"); return 1879000;}
+      case RequestType::READUSER:
+            if (td->nbHops == 1)
+            {
+                  XBT_DEBUG("Entered cost Function for READUSER");
+                  return 1879000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_home_timeline_service(TaskDescription* td) {
+double pr_home_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service home_timeline_service");
       switch (td->requestType)
       {
-case RequestType::READHOME:
-      if(td->nbHops == 2){XBT_DEBUG("Entered cost Function for READHOME"); return 1142000;}
+      case RequestType::READHOME:
+            if (td->nbHops == 2)
+            {
+                  XBT_DEBUG("Entered cost Function for READHOME");
+                  return 1142000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_post_storage_service(TaskDescription* td) {
+double pr_post_storage_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service post_storage_service");
       switch (td->requestType)
       {
-case RequestType::READHOME:
-      if(td->nbHops == 3){XBT_DEBUG("Entered cost Function for READHOME (FINAL NODE, NO CHILD!)"); return 17000;}
+      case RequestType::READHOME:
+            if (td->nbHops == 3)
+            {
+                  XBT_DEBUG("Entered cost Function for READHOME (FINAL NODE, NO CHILD!)");
+                  return 17000;
+            }
 
-break;
+            break;
 
-case RequestType::READUSER:
-      if(td->nbHops == 3){XBT_DEBUG("Entered cost Function for READUSER (FINAL NODE, NO CHILD!)"); return 17000;}
+      case RequestType::READUSER:
+            if (td->nbHops == 3)
+            {
+                  XBT_DEBUG("Entered cost Function for READUSER (FINAL NODE, NO CHILD!)");
+                  return 17000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-    double pr_user_timeline_service(TaskDescription* td) {
+double pr_user_timeline_service(TaskDescription *td)
+{
       XBT_DEBUG("pr function of service user_timeline_service");
       switch (td->requestType)
       {
-case RequestType::READUSER:
-      if(td->nbHops == 2){XBT_DEBUG("Entered cost Function for READUSER"); return 2355000;}
+      case RequestType::READUSER:
+            if (td->nbHops == 2)
+            {
+                  XBT_DEBUG("Entered cost Function for READUSER");
+                  return 2355000;
+            }
 
-break;
-	}//it should never end up here
-return -1;
+            break;
+      } // it should never end up here
+      return -1;
 }
-  void run() {
-    XBT_INFO("Starting run()");
+void run()
+{
+      XBT_INFO("Starting run()");
 
-    // create ETM for service nginx_web_server
-    std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();
-    v_serv_nginx_web_server.push_back("nginx_web_server");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_nginx_web_server = std::make_shared<sg_microserv::ElasticTaskManager>("nginx_web_server",v_serv_nginx_web_server);
-    serv_nginx_web_server->setBootDuration(0);
-    serv_nginx_web_server->setOutputFunction(return_nginx_web_server);
-    serv_nginx_web_server->setExecAmountFunc(pr_nginx_web_server);
-    serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name("cb1-1"));
-    simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name("cb1-1"), [serv_nginx_web_server] { serv_nginx_web_server->run(); });
+      // create ETM for service nginx_web_server
+      std::vector<std::string> v_serv_nginx_web_server = std::vector<std::string>();
+      v_serv_nginx_web_server.push_back("nginx_web_server");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_nginx_web_server = std::make_shared<sg_microserv::ElasticTaskManager>("nginx_web_server", v_serv_nginx_web_server);
+      serv_nginx_web_server->setBootDuration(0);
+      serv_nginx_web_server->setOutputFunction(return_nginx_web_server);
+      serv_nginx_web_server->setExecAmountFunc(pr_nginx_web_server);
+      serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name("cb1-1"));
+      simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name("cb1-1"), [serv_nginx_web_server]
+                                  { serv_nginx_web_server->run(); });
 
+      // create ETM for service home_timeline_service
+      std::vector<std::string> v_serv_home_timeline_service = std::vector<std::string>();
+      v_serv_home_timeline_service.push_back("home_timeline_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_home_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("home_timeline_service", v_serv_home_timeline_service);
+      serv_home_timeline_service->setBootDuration(0);
+      serv_home_timeline_service->setOutputFunction(return_home_timeline_service);
+      serv_home_timeline_service->setExecAmountFunc(pr_home_timeline_service);
+      serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name("cb1-2"));
+      simgrid::s4u::Actor::create("etm_home_timeline_service", simgrid::s4u::Host::by_name("cb1-2"), [serv_home_timeline_service]
+                                  { serv_home_timeline_service->run(); });
 
-    // create ETM for service home_timeline_service
-    std::vector<std::string> v_serv_home_timeline_service = std::vector<std::string>();
-    v_serv_home_timeline_service.push_back("home_timeline_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_home_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("home_timeline_service",v_serv_home_timeline_service);
-    serv_home_timeline_service->setBootDuration(0);
-    serv_home_timeline_service->setOutputFunction(return_home_timeline_service);
-    serv_home_timeline_service->setExecAmountFunc(pr_home_timeline_service);
-    serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name("cb1-2"));
-    simgrid::s4u::Actor::create("etm_home_timeline_service", simgrid::s4u::Host::by_name("cb1-2"), [serv_home_timeline_service] { serv_home_timeline_service->run(); });
+      // create ETM for service post_storage_service
+      std::vector<std::string> v_serv_post_storage_service = std::vector<std::string>();
+      v_serv_post_storage_service.push_back("post_storage_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_post_storage_service = std::make_shared<sg_microserv::ElasticTaskManager>("post_storage_service", v_serv_post_storage_service);
+      serv_post_storage_service->setBootDuration(0);
+      serv_post_storage_service->setOutputFunction(return_post_storage_service);
+      serv_post_storage_service->setExecAmountFunc(pr_post_storage_service);
+      serv_post_storage_service->addHost(simgrid::s4u::Host::by_name("cb1-3"));
+      simgrid::s4u::Actor::create("etm_post_storage_service", simgrid::s4u::Host::by_name("cb1-3"), [serv_post_storage_service]
+                                  { serv_post_storage_service->run(); });
 
+      // create ETM for service user_timeline_service
+      std::vector<std::string> v_serv_user_timeline_service = std::vector<std::string>();
+      v_serv_user_timeline_service.push_back("user_timeline_service");
+      std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_timeline_service", v_serv_user_timeline_service);
+      serv_user_timeline_service->setBootDuration(0);
+      serv_user_timeline_service->setOutputFunction(return_user_timeline_service);
+      serv_user_timeline_service->setExecAmountFunc(pr_user_timeline_service);
+      serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name("cb1-4"));
+      simgrid::s4u::Actor::create("etm_user_timeline_service", simgrid::s4u::Host::by_name("cb1-4"), [serv_user_timeline_service]
+                                  { serv_user_timeline_service->run(); });
 
-    // create ETM for service post_storage_service
-    std::vector<std::string> v_serv_post_storage_service = std::vector<std::string>();
-    v_serv_post_storage_service.push_back("post_storage_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_post_storage_service = std::make_shared<sg_microserv::ElasticTaskManager>("post_storage_service",v_serv_post_storage_service);
-    serv_post_storage_service->setBootDuration(0);
-    serv_post_storage_service->setOutputFunction(return_post_storage_service);
-    serv_post_storage_service->setExecAmountFunc(pr_post_storage_service);
-    serv_post_storage_service->addHost(simgrid::s4u::Host::by_name("cb1-3"));
-    simgrid::s4u::Actor::create("etm_post_storage_service", simgrid::s4u::Host::by_name("cb1-3"), [serv_post_storage_service] { serv_post_storage_service->run(); });
+      /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
+      DataSourceFixedInterval *dsf = new DataSourceFixedInterval("nginx_web_server", RequestType::READUSER, 30, 100);
+      simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]
+                                                                 { dsf->run(); });
 
+      DataSourceFixedInterval *dsf2 = new DataSourceFixedInterval("nginx_web_server", RequestType::READHOME, 51, 100);
+      simgrid::s4u::ActorPtr dataS2 = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]
+                                                                  { dsf2->run(); });
 
-    // create ETM for service user_timeline_service
-    std::vector<std::string> v_serv_user_timeline_service = std::vector<std::string>();
-    v_serv_user_timeline_service.push_back("user_timeline_service");
-    std::shared_ptr<sg_microserv::ElasticTaskManager> serv_user_timeline_service = std::make_shared<sg_microserv::ElasticTaskManager>("user_timeline_service",v_serv_user_timeline_service);
-    serv_user_timeline_service->setBootDuration(0);
-    serv_user_timeline_service->setOutputFunction(return_user_timeline_service);
-    serv_user_timeline_service->setExecAmountFunc(pr_user_timeline_service);
-    serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name("cb1-4"));
-    simgrid::s4u::Actor::create("etm_user_timeline_service", simgrid::s4u::Host::by_name("cb1-4"), [serv_user_timeline_service] { serv_user_timeline_service->run(); });
+      // kill policies and ETMs
+      simgrid::s4u::this_actor::sleep_for(150); /*set it according to your needs*/
+      XBT_INFO("Done. Killing policies and etms");
+      dataS->kill();
+      dataS2->kill();
+      // kill policies and ETMs
+      simgrid::s4u::this_actor::sleep_for(150); /*set it according to your needs*/
+      XBT_INFO("Done. Killing policies and etms");
 
-
-
-  /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
-  DataSourceFixedInterval* dsf = new DataSourceFixedInterval("nginx_web_server",RequestType::READUSER, 30,100);
-  simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]{dsf->run();});
-
-  DataSourceFixedInterval* dsf2 = new DataSourceFixedInterval("nginx_web_server",RequestType::READHOME, 51,100);
-  simgrid::s4u::ActorPtr dataS2 = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]{dsf2->run();});
-
-  // kill policies and ETMs
-  simgrid::s4u::this_actor::sleep_for(150); /*set it according to your needs*/
-  XBT_INFO("Done. Killing policies and etms");
-    dataS->kill();
-    dataS2->kill();
-  // kill policies and ETMs
-  simgrid::s4u::this_actor::sleep_for(150); /*set it according to your needs*/
-  XBT_INFO("Done. Killing policies and etms");
-
-    serv_nginx_web_server->kill();
-    serv_home_timeline_service->kill();
-    serv_post_storage_service->kill();
-    serv_user_timeline_service->kill();
+      serv_nginx_web_server->kill();
+      serv_home_timeline_service->kill();
+      serv_post_storage_service->kill();
+      serv_user_timeline_service->kill();
 }
-int main(int argc, char* argv[]) {
-	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
+int main(int argc, char *argv[])
+{
+      simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
 
-	e->load_platform(argv[1]);
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run();});
-	e->run();
-	return 0;
+      e->load_platform(argv[1]);
+      simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]
+                                  { run(); });
+      e->run();
+      return 0;
 }

--- a/examples/test2req.cpp
+++ b/examples/test2req.cpp
@@ -217,7 +217,7 @@ void run()
       serv_nginx_web_server->setOutputFunction(return_nginx_web_server);
       serv_nginx_web_server->setExecAmountFunc(pr_nginx_web_server);
       serv_nginx_web_server->addHost(simgrid::s4u::Host::by_name("cb1-1"));
-      simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name("cb1-1"), [serv_nginx_web_server]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_nginx_web_server", simgrid::s4u::Host::by_name("cb1-1"), [serv_nginx_web_server]
                                   { serv_nginx_web_server->run(); });
 
       // create ETM for service home_timeline_service
@@ -228,7 +228,7 @@ void run()
       serv_home_timeline_service->setOutputFunction(return_home_timeline_service);
       serv_home_timeline_service->setExecAmountFunc(pr_home_timeline_service);
       serv_home_timeline_service->addHost(simgrid::s4u::Host::by_name("cb1-2"));
-      simgrid::s4u::Actor::create("etm_home_timeline_service", simgrid::s4u::Host::by_name("cb1-2"), [serv_home_timeline_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_home_timeline_service", simgrid::s4u::Host::by_name("cb1-2"), [serv_home_timeline_service]
                                   { serv_home_timeline_service->run(); });
 
       // create ETM for service post_storage_service
@@ -239,7 +239,7 @@ void run()
       serv_post_storage_service->setOutputFunction(return_post_storage_service);
       serv_post_storage_service->setExecAmountFunc(pr_post_storage_service);
       serv_post_storage_service->addHost(simgrid::s4u::Host::by_name("cb1-3"));
-      simgrid::s4u::Actor::create("etm_post_storage_service", simgrid::s4u::Host::by_name("cb1-3"), [serv_post_storage_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_post_storage_service", simgrid::s4u::Host::by_name("cb1-3"), [serv_post_storage_service]
                                   { serv_post_storage_service->run(); });
 
       // create ETM for service user_timeline_service
@@ -250,16 +250,16 @@ void run()
       serv_user_timeline_service->setOutputFunction(return_user_timeline_service);
       serv_user_timeline_service->setExecAmountFunc(pr_user_timeline_service);
       serv_user_timeline_service->addHost(simgrid::s4u::Host::by_name("cb1-4"));
-      simgrid::s4u::Actor::create("etm_user_timeline_service", simgrid::s4u::Host::by_name("cb1-4"), [serv_user_timeline_service]
+      simgrid::s4u::Engine::get_instance()->add_actor("etm_user_timeline_service", simgrid::s4u::Host::by_name("cb1-4"), [serv_user_timeline_service]
                                   { serv_user_timeline_service->run(); });
 
       /* ADD DATASOURCES MANUALLY HERE, SET THE END TIMER AS YOU WISH, AND LAUNCH YOUR SIMULATOR*/
       DataSourceFixedInterval *dsf = new DataSourceFixedInterval("nginx_web_server", RequestType::READUSER, 30, 100);
-      simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]
+      simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]
                                                                  { dsf->run(); });
 
       DataSourceFixedInterval *dsf2 = new DataSourceFixedInterval("nginx_web_server", RequestType::READHOME, 51, 100);
-      simgrid::s4u::ActorPtr dataS2 = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]
+      simgrid::s4u::ActorPtr dataS2 = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]
                                                                   { dsf2->run(); });
 
       // kill policies and ETMs
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
       simgrid::s4u::Engine *e = new simgrid::s4u::Engine(&argc, argv);
 
       e->load_platform(argv[1]);
-      simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]
+      simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name("cb1-200"), [&]
                                   { run(); });
       e->run();
       return 0;

--- a/examples/testDoc.cpp
+++ b/examples/testDoc.cpp
@@ -74,7 +74,7 @@ void run() {
   etmservice1->addHost(simgrid::s4u::Host::by_name("cb1-4"));
   etmservice1->setExecAmount(1e7);
   etmservice1->setBootDuration(2);
-  simgrid::s4u::Actor::create("etmservice1_a", simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice1_a", simgrid::s4u::Host::by_name("cb1-1"), [etmservice1] { etmservice1->run(); });
 
 
   /* ETM2 */
@@ -87,7 +87,7 @@ void run() {
   etmservice2->addHost(simgrid::s4u::Host::by_name("cb1-102"));
   etmservice2->setExecAmount(5e6);
   etmservice2->setBootDuration(1);
-  simgrid::s4u::Actor::create("etmservice2_a", simgrid::s4u::Host::by_name("cb1-100"), [etmservice2] { etmservice2->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etmservice2_a", simgrid::s4u::Host::by_name("cb1-100"), [etmservice2] { etmservice2->run(); });
 
 
   /*
@@ -100,7 +100,7 @@ void run() {
     *
   */
   DataSourceFixedInterval* ds = new DataSourceFixedInterval("service1", 1, 10000);
-	simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
+	simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("cb1-1"), [&]{ds->run();});
 
   // kill policies and ETMs
   simgrid::s4u::this_actor::sleep_for(300);
@@ -114,7 +114,7 @@ void run() {
 int main(int argc, char* argv[]) {
 	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
 	e->load_platform(argv[1]);
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run();});
+	simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run();});
 	e->run();
 	return 0;
 }

--- a/examples/testReqTypes.cpp
+++ b/examples/testReqTypes.cpp
@@ -117,14 +117,14 @@ void run() {
 
 
   // create actors
-  simgrid::s4u::Actor::create("etm_nginx_web_server", simgrid::s4u::Host::by_name("cb1-1"), [serv_nginx_web_server] { serv_nginx_web_server->run(); });
-  simgrid::s4u::Actor::create("etm_user_timeline", simgrid::s4u::Host::by_name("cb1-2"), [serv_user_timeline] { serv_user_timeline->run(); });
-  simgrid::s4u::Actor::create("etm_post_storage", simgrid::s4u::Host::by_name("cb1-3"), [serv_post_storage] { serv_post_storage->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_nginx_web_server", simgrid::s4u::Host::by_name("cb1-1"), [serv_nginx_web_server] { serv_nginx_web_server->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_user_timeline", simgrid::s4u::Host::by_name("cb1-2"), [serv_user_timeline] { serv_user_timeline->run(); });
+  simgrid::s4u::Engine::get_instance()->add_actor("etm_post_storage", simgrid::s4u::Host::by_name("cb1-3"), [serv_post_storage] { serv_post_storage->run(); });
 
 
   /*create datasource*/
   DataSourceFixedInterval* dsf = new DataSourceFixedInterval("nginx_web_server",RequestType::TESTREQ_EXAMPLE, 5,100);
-  simgrid::s4u::ActorPtr dataS = simgrid::s4u::Actor::create("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]{dsf->run();});
+  simgrid::s4u::ActorPtr dataS = simgrid::s4u::Engine::get_instance()->add_actor("snd", simgrid::s4u::Host::by_name("cb1-100"), [&]{dsf->run();});
 
 
   // kill policies and ETMs
@@ -139,7 +139,7 @@ int main(int argc, char* argv[]) {
 	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
 
 	e->load_platform(argv[1]);
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run();});
+	simgrid::s4u::Engine::get_instance()->add_actor("main", simgrid::s4u::Host::by_name("cb1-200"), [&]{run();});
 	e->run();
 	return 0;
 }

--- a/script/codeGen.py
+++ b/script/codeGen.py
@@ -346,7 +346,7 @@ def genETMInitCode(graphs, parDeg=10):
     serv_%s->setReqNames(reqTypeToStr);
     // set the host location in the config file (location)
     serv_%s->addHost(simgrid::s4u::Host::by_name(configServices.find(\"%s\")->second.at(0)));
-    simgrid::s4u::Actor::create("etm_%s", simgrid::s4u::Host::by_name(configServices.find(\"%s\")->second.at(0)), [serv_%s] { serv_%s->run(); });
+    simgrid::s4u::Engine::get_instance()->add_actor("etm_%s", simgrid::s4u::Host::by_name(configServices.find(\"%s\")->second.at(0)), [serv_%s] { serv_%s->run(); });
 
     """%(service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service,service)
     hostIndex+=1
@@ -495,7 +495,7 @@ int main(int argc, char* argv[]) {
 	simgrid::s4u::Engine* e = new simgrid::s4u::Engine(&argc, argv);
 
 	e->load_platform(argv[1]);
-	simgrid::s4u::Actor::create("main", simgrid::s4u::Host::by_name(servConfig.find(\"default\")->second.at(0)), [&] {run(servConfig);});
+	e->add_actor("main", simgrid::s4u::Host::by_name(servConfig.find(\"default\")->second.at(0)), [&] {run(servConfig);});
 	e->run();
 	return 0;
 }

--- a/tools/cmake/FindSimGrid.cmake
+++ b/tools/cmake/FindSimGrid.cmake
@@ -1,6 +1,6 @@
-# CMake find module to search for the SimGrid library. 
+# CMake find module to search for the SimGrid library.
 
-# Copyright (c) 2016-2021. The SimGrid Team.
+# Copyright (c) 2016-2025. The SimGrid Team. All rights reserved.
 #
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the license (GNU LGPL) which comes with this package.
@@ -13,7 +13,7 @@
 #    CMAKE_PREFIX_PATH="/path/to/FindSimGrid.cmake:$CMAKE_PREFIX_PATH"  cmake .
 #
 # If this file does not find SimGrid, define SimGrid_PATH:
-#    SimGrid_PATH=/path/to/simgrid  cmake .
+#    cmake -DSIMGRID_PATH=/path/to/simgrid .
 
 #
 # DEVELOPERS OF PROGRAMS USING SIMGRID
@@ -23,32 +23,37 @@
 #     Either by copying it in your tree, or (recommended) by using the
 #     version automatically installed by SimGrid.
 #
-#  2. Afterward, if you have CMake >= 2.8.12, this will define a
-#     target called 'SimGrid::Simgrid'. Use it as:
+#  2. This will define a target called 'SimGrid::Simgrid'. Use it as:
 #       target_link_libraries(your-simulator SimGrid::SimGrid)
 #
-#    With older CMake (< 2.8.12), it simply defines several variables:
-#       SimGrid_INCLUDE_DIR - the SimGrid include directories
-#       SimGrid_LIBRARY - link your simulator against it to use SimGrid
-#    Use as:
-#      include_directories("${SimGrid_INCLUDE_DIR}" SYSTEM)
-#      target_link_libraries(your-simulator ${SimGrid_LIBRARY})
+#  It also defines a SIMGRID_VERSION macro, that you can use to deal with API
+#    evolutions as follows:
 #
-#  In both cases, it also define a SimGrid_VERSION macro, that you
-#    can use to deal with API evolutions as follows:
-#
-#    #if SimGrid_VERSION < 31800
+#    #include <simgrid/version.h>
+#    #if SIMGRID_VERSION < 31800
 #      (code to use if the installed version is lower than v3.18)
-#    #elif SimGrid_VERSION < 31900
+#    #elif SIMGRID_VERSION < 31900
 #      (code to use if we are using SimGrid v3.18.x)
 #    #else
-#      (code to use with SimGrid v3.19+)
+#      (code to use with SimGrid v3.19 or later)
 #    #endif
 #
-#  Since SimGrid header files require C++14, so we set CMAKE_CXX_STANDARD to 14.
+#  Since SimGrid header files require C++17, we set CMAKE_CXX_STANDARD to 17.
 #    Change this variable in your own file if you need a later standard.
 
-# 
+# DEVELOPPERS OF MPI PROGRAMS USING SIMGRID
+#   You should use smpi_c_target() on the targets that are intended to run in SMPI.
+#   ${SMPIRUN} is correctly set if it's installed.
+#
+#   Example:
+#     add_executable(roundtrip roundtrip.c)
+#     smpi_c_target(roundtrip)
+#
+#     enable_testing()
+#     add_test(NAME Roundtrip
+#              COMMAND ${SMPIRUN} -platform ${CMAKE_SOURCE_DIR}/../cluster_backbone.xml -np 2 ./roundtrip)
+
+#
 # IMPROVING THIS FILE
 # -------------------
 #  - Use automatic SimGridConfig.cmake creation via export/install(EXPORT in main CMakeLists.txt:
@@ -56,26 +61,26 @@
 #    https://cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file
 #    https://github.com/boostcon/cppnow_presentations_2017/blob/master/05-19-2017_friday/effective_cmake__daniel_pfeifer__cppnow_05-19-2017.pdf
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_path(SimGrid_INCLUDE_DIR
   NAMES simgrid/config.h
   NAMES simgrid/version.h
-  PATHS ${SimGrid_PATH}/include /opt/simgrid/include
+  PATHS ${SimGrid_PATH}/include ${SIMGRID_PATH}/include /opt/simgrid/include
 )
 if (NOT SimGrid_INCLUDE_DIR)
   # search under the old name
   find_path(SimGrid_INCLUDE_DIR
     NAMES simgrid_config.h
-    PATHS ${SimGrid_PATH}/include /opt/simgrid/include
+    PATHS ${SimGrid_PATH}/include ${SIMGRID_PATH}/include /opt/simgrid/include
   )
-endif()    
+endif()
 find_library(SimGrid_LIBRARY
   NAMES simgrid
-  PATHS ${SimGrid_PATH}/lib /opt/simgrid/lib
+  PATHS ${SimGrid_PATH}/lib ${SIMGRID_PATH}/lib /opt/simgrid/lib
 )
 mark_as_advanced(SimGrid_INCLUDE_DIR)
 mark_as_advanced(SimGrid_LIBRARY)
@@ -100,7 +105,7 @@ if (SimGrid_INCLUDE_DIR)
     set(SimGrid_VERSION_${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
   endforeach()
   unset(SimGrid_VERSION_STRING)
-  unset(SimGrid_VERSION_REGEX)  
+  unset(SimGrid_VERSION_REGEX)
 endif ()
 
 include(FindPackageHandleStandardArgs)
@@ -110,35 +115,42 @@ find_package_handle_standard_args(SimGrid
   VERSION_VAR SimGrid_VERSION
 )
 
-if (SimGrid_FOUND AND NOT CMAKE_VERSION VERSION_LESS 2.8.12)
+if (SimGrid_FOUND)
+
+  find_program(SMPIRUN smpirun
+               HINTS ${SimGrid_PATH}/bin /opt/simgrid/bin)
+
+  MACRO(smpi_c_target NAME)
+    target_compile_options(${NAME} PUBLIC "-include;smpi/smpi_helpers.h;-fPIC;-shared;-Wl,-z,defs")
+    target_link_options(${NAME} PUBLIC "-fPIC;-shared;-Wl,-z,defs;-lm")
+    target_link_libraries(${NAME} PUBLIC ${SimGrid_LIBRARY})
+    target_include_directories(${NAME} PUBLIC "${SimGrid_INCLUDE_DIR};${SimGrid_INCLUDE_DIR}/smpi")
+  ENDMACRO()
+
   add_library(SimGrid::SimGrid SHARED IMPORTED)
   set_target_properties(SimGrid::SimGrid PROPERTIES
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${SimGrid_INCLUDE_DIR}
     INTERFACE_COMPILE_FEATURES cxx_alias_templates
     IMPORTED_LOCATION ${SimGrid_LIBRARY}
   )
-  # We need C++14, so check for it just in case the user removed it since compiling SimGrid
+  # We need C++17, so check for it just in case the user removed it since compiling SimGrid
   if (NOT CMAKE_VERSION VERSION_LESS 3.8)
-    # 3.8+ allows us to simply require C++14 (or higher)
-    set_property(TARGET SimGrid::SimGrid PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
-  elseif (NOT CMAKE_VERSION VERSION_LESS 3.1)
-    # 3.1+ is similar but for certain features. We pick just one
-    set_property(TARGET SimGrid::SimGrid PROPERTY INTERFACE_COMPILE_FEATURES cxx_attribute_deprecated)
+    # 3.8+ allows us to simply require C++17 (or higher)
+    set_property(TARGET SimGrid::SimGrid PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_17)
   else ()
-    # Old CMake can't do much. Just check the CXX_FLAGS and inform the user when a C++14 feature does not work
+    # Old CMake can't do much. Just check the CXX_FLAGS and inform the user when a C++17 feature does not work
     include(CheckCXXSourceCompiles)
     set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS}")
     check_cxx_source_compiles("
-#if __cplusplus < 201402L
+#if __cplusplus < 201703L
 #error
 #else
 int main(){}
 #endif
-" _SIMGRID_CXX14_ENABLED)
-    if (NOT _SIMGRID_CXX14_ENABLED)
-        message(WARNING "C++14 is required to use SimGrid. Enable it with e.g. -std=c++14")
+" _SIMGRID_CXX17_ENABLED)
+    if (NOT _SIMGRID_CXX17_ENABLED)
+        message(WARNING "C++17 is required to use SimGrid. Enable it with e.g. -std=c++17")
     endif ()
     unset(_SIMGRID_CXX14_ENABLED CACHE)
   endif ()
 endif ()
-


### PR DESCRIPTION
In this pull request, I have made three main modifications:

1. I've updated the SimGrid usage for version 4.0. To do it, I've adapted all executions (simgrid::s4u::this_actor::exec_init) and communications to use the activities (simgrid::s4u::ActivitySet wait_any instead of simgrid::s4u::Comm::wait_any);
2. I've created a NixOS file to download and install the majority of the dependencies (everything but Jaeger Tracing. See below for the reason);
3. I've implemented a beginning of elasticity policy based on Kubernetes and LeastAllocated placement. LeastAllocated will put new replicas on the machines with the least usage (Kubernetes default). The source code is ElasticPolicyCPUKubLeast.cpp. To allow this policy, I've needed to create a new plugin for SimGrid, to calculate the load by VM (similar to HostLoad plugin). I've done a [pull request](https://github.com/simgrid/simgrid/pull/406) of this plugin in the main source code. When accepted and included in the NixOS packages, we can simplify the NixOS file.

Currently, there is an open issue: [Jaeger Tracing](https://github.com/jaegertracing/jaeger-client-cpp) used in the base source code is deprecated. The developers migrated it to [OpenTelemetry](https://opentelemetry.io/). I'll open an issue for changing it. 
For the moment, when Jaeger is not enabled, I've exported the results in some CSV files. This needs to be improved in some way (maybe adapting the Jaeger to OpenTelemetry).